### PR TITLE
feat: stop spring support publish temporary

### DIFF
--- a/libs/developers-tx-result-adapter-spring-support/build.gradle.kts
+++ b/libs/developers-tx-result-adapter-spring-support/build.gradle.kts
@@ -156,7 +156,3 @@ fun setPublishingContext() {
         sign(publishing.publications[project.name])
     }
 }
-
-if (project.gradle.startParameter.taskNames.contains("publish")) {
-    setPublishingContext()
-}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,7 +3,7 @@
  * LINE Corporation PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
  */
 
-rootProject.name = "developers-tx-result-adapter"
+rootProject.name = "line-blockchain-developers-sdk-kt"
 
 // libs
 listOf(


### PR DESCRIPTION
### What kind of change does this PR introduce?
* [ ] bug fix
* [x] feature
* [ ] docs
* [ ] update

### What is the new behavior?
stop spring support publish temporary to publish developers-tx-result-adapter first