### PR TITLE
fix: tx-result properties name

### DIFF
--- a/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/txresult/core/model/models.kt
+++ b/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/txresult/core/model/models.kt
@@ -22,8 +22,8 @@ import org.apache.commons.lang3.StringUtils
 
 data class TxResult(
     val summary: TxResultSummary,
-    val txMessages: Set<TxMessage>,
-    val txEvents: Set<TransactionEvent>,
+    val messages: Set<TxMessage>,
+    val events: Set<TransactionEvent>,
 )
 
 data class TxResultSummary(

--- a/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxResultAdapterV1.kt
+++ b/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxResultAdapterV1.kt
@@ -31,8 +31,8 @@ class DomainTxResultAdapterV1(
     override fun adapt(input: RawTransactionResult): TxResult {
         return TxResult(
             summary = txResultSummaryAdapter.adapt(input),
-            txMessages = txMessageAdapter.adapt(input),
-            txEvents = txEventsAdapter.adapt(input),
+            messages = txMessageAdapter.adapt(input),
+            events = txEventsAdapter.adapt(input),
         )
     }
 }

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxResultAdapterV1Test.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxResultAdapterV1Test.kt
@@ -70,9 +70,9 @@ class DomainTxResultAdapterV1Test {
         assertEquals("", txResult.summary.result.codeSpace)
         assertEquals(0, txResult.summary.result.code)
 
-        assertEquals(1, txResult.txMessages.size)
-        assertNotNull(txResult.txMessages.find { it.requestType == "collection/MsgMintFT" })
-        val txResultMessage = txResult.txMessages.find { it.requestType == "collection/MsgMintFT" }
+        assertEquals(1, txResult.messages.size)
+        assertNotNull(txResult.messages.find { it.requestType == "collection/MsgMintFT" })
+        val txResultMessage = txResult.messages.find { it.requestType == "collection/MsgMintFT" }
         val details = txResultMessage?.details as Map<String, String>
         assertEquals(details["from"], "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq")
         assertEquals(details["contractId"], "61e14383")
@@ -81,7 +81,7 @@ class DomainTxResultAdapterV1Test {
         assertEquals(amounts[0]["tokenId"], "0000000100000000")
         assertEquals(amounts[0]["amount"], 1000)
 
-        val mintFtEvent = txResult.txEvents.firstOrNull { it::class == EventCollectionFtMinted::class }
+        val mintFtEvent = txResult.events.firstOrNull { it::class == EventCollectionFtMinted::class }
         assertNotNull(mintFtEvent)
         assertEquals((mintFtEvent as EventCollectionFtMinted).contractId, "61e14383")
     }


### PR DESCRIPTION
### What kind of change does this PR introduce?
* [x] bug fix
* [ ] feature
* [ ] docs
* [ ] update

### What is the current behavior? 
Fail to parse actual tx-result response from LBD

### What is the new behavior?
Update properties name 
* PTAL https://docs-blockchain.line.biz/api-guide/Callback-Response#transaction-result
