### PR TITLE
fix: add deserializer for TransactionEvent

### DIFF
--- a/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/jackson/TransactionEventDeserializer.kt
+++ b/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/jackson/TransactionEventDeserializer.kt
@@ -1,0 +1,404 @@
+/*
+ *   Copyright 2023 LINE Corporation
+ *
+ *   LINE Corporation licenses this file to you under the Apache License,
+ *   version 2.0 (the "License"); you may not use this file except in compliance
+ *   with the License. You may obtain a copy of the License at:
+ *
+ *     https:www.apache.orglicensesLICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *   License for the specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+
+@file:Suppress("DuplicatedCode")
+
+package com.linecorp.link.developers.jackson
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.linecorp.link.developers.txresult.core.event.UnknownTransactionEvent
+import com.linecorp.link.developers.txresult.core.event.account.EventAccountCreated
+import com.linecorp.link.developers.txresult.core.event.account.EventEmptyMsgCreated
+import com.linecorp.link.developers.txresult.core.event.bank.EventCoinTransferred
+import com.linecorp.link.developers.txresult.core.event.item.CollectionAttribute
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionCreated
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionFtBurned
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionFtIssued
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionFtMinted
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionFtModified
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionFtTransferred
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionModified
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionNftAttached
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionNftBurned
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionNftDetached
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionNftHolderChanged
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionNftIssued
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionNftMinted
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionNftModified
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionNftRootChanged
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionNftTransferred
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionNftTypeModified
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionPermissionGranted
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionPermissionRenounced
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionProxyApproved
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionProxyDisapproved
+import com.linecorp.link.developers.txresult.core.event.item.ItemTokenPermission
+import com.linecorp.link.developers.txresult.core.event.token.EventTokenBurned
+import com.linecorp.link.developers.txresult.core.event.token.EventTokenIssued
+import com.linecorp.link.developers.txresult.core.event.token.EventTokenMinted
+import com.linecorp.link.developers.txresult.core.event.token.EventTokenModified
+import com.linecorp.link.developers.txresult.core.event.token.EventTokenPermissionGranted
+import com.linecorp.link.developers.txresult.core.event.token.EventTokenPermissionRenounced
+import com.linecorp.link.developers.txresult.core.event.token.EventTokenProxyApproved
+import com.linecorp.link.developers.txresult.core.event.token.EventTokenProxyDisapproved
+import com.linecorp.link.developers.txresult.core.event.token.EventTokenTransferred
+import com.linecorp.link.developers.txresult.core.event.token.TokenAttribute
+import com.linecorp.link.developers.txresult.core.event.token.TokenPermission
+import com.linecorp.link.developers.txresult.core.model.TransactionEvent
+
+class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): TransactionEvent {
+        val mapTypeReference = object : TypeReference<Map<Any, Any?>>() {}
+        val value: Map<Any, Any?> = p.readValueAs(mapTypeReference)
+        return when {
+            value["eventName"] == "EventCoinTransferred" -> {
+                EventCoinTransferred(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    denomination = value["denomination"].toString(),
+                    fromAddress = value["fromAddress"].toString(),
+                    toAddress = value["toAddress"].toString(),
+                    amount = value["amount"].toString(),
+                )
+            }
+            value["eventName"] == "EventAccountCreated" -> {
+                EventAccountCreated(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    createdAddress = value["createdAddress"].toString(),
+                )
+            }
+            value["eventName"] == "EventEmptyMsgCreated" -> {
+                EventEmptyMsgCreated(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    senderAddress = value["senderAddress"].toString(),
+                )
+            }
+            value["eventName"] == "EventTokenBurned" -> {
+                EventTokenBurned(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    fromAddress = value["fromAddress"].toString(),
+                    proxyAddress = value["proxyAddress"]?.toString(),
+                    amount = value["amount"].toString(),
+                )
+            }
+            value["eventName"] == "EventTokenIssued" -> {
+                EventTokenIssued(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    issuerAddress = value["issuerAddress"].toString(),
+                    receiverAddress = value["receiverAddress"].toString(),
+                    name = value["name"].toString(),
+                    symbol = value["symbol"].toString(),
+                    decimals = value["decimals"].toString().toInt(),
+                    amount = value["amount"].toString(),
+                )
+            }
+            value["eventName"] == "EventTokenMinted" -> {
+                EventTokenMinted(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    minterAddress = value["minterAddress"].toString(),
+                    toAddress = value["toAddress"].toString(),
+                    amount = value["amount"].toString(),
+                )
+            }
+            value["eventName"] == "EventTokenTransferred" -> {
+                EventTokenTransferred(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    fromAddress = value["minterAddress"].toString(),
+                    proxyAddress = value["proxyAddress"]?.toString(),
+                    toAddress = value["toAddress"].toString(),
+                    amount = value["amount"].toString(),
+                )
+            }
+            value["eventName"] == "EventTokenModified" -> {
+                EventTokenModified(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    modifierAddress = value["modifierAddress"].toString(),
+                    tokenAttributes = deserializeTokenAttributes(value)
+                )
+            }
+            value["eventName"] == "EventTokenPermissionGranted" -> {
+                val permissionTypeRef = object : TypeReference<TokenPermission>() {}
+                EventTokenPermissionGranted(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    granteeAddress = value["granteeAddress"].toString(),
+                    granterAddress = value["granterAddress"].toString(),
+                    permission = p.readValueAs(permissionTypeRef)
+                )
+            }
+            value["eventName"] == "EventTokenPermissionRenounced" -> {
+                val permissionTypeRef = object : TypeReference<TokenPermission>() {}
+                EventTokenPermissionRenounced(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    granteeAddress = value["granteeAddress"].toString(),
+                    permission = p.readValueAs(permissionTypeRef)
+                )
+            }
+            value["eventName"] == "EventTokenProxyApproved" -> {
+                EventTokenProxyApproved(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    approverAddress = value["approverAddress"].toString(),
+                    proxyAddress = value["proxyAddress"].toString(),
+                )
+            }
+            value["eventName"] == "EventTokenProxyDisapproved" -> {
+                EventTokenProxyDisapproved(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    approverAddress = value["approverAddress"].toString(),
+                    proxyAddress = value["proxyAddress"].toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionCreated" -> {
+                EventCollectionCreated(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    name = value["name"].toString(),
+                    creatorAddress = value["creatorAddress"].toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionModified" -> {
+                EventCollectionModified(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    tokenAttributes = deserializeCollectionAttributes(value),
+                    modifierAddress = value["modifierAddress"].toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionFtIssued" -> {
+                EventCollectionFtIssued(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    tokenType = value["tokenType"].toString(),
+                    name = value["name"].toString(),
+                    amount = value["amount"].toString(),
+                    decimals = value["decimals"].toString().toInt(),
+                    issuerAddress = value["issuerAddress"].toString(),
+                    receiverAddress = value["receiverAddress"].toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionFtMinted" -> {
+                EventCollectionFtMinted(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    tokenType = value["tokenType"].toString(),
+                    tokenId = value["tokenId"].toString(),
+                    amount = value["amount"].toString(),
+                    toAddress = value["toAddress"].toString(),
+                    minterAddress = value["minterAddress"].toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionFtModified" -> {
+                EventCollectionFtModified(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    tokenType = value["tokenType"].toString(),
+                    tokenAttributes = deserializeCollectionAttributes(value),
+                    modifierAddress = value["modifierAddress"].toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionFtTransferred" -> {
+                EventCollectionFtTransferred(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    tokenType = value["tokenType"].toString(),
+                    tokenId = value["tokenId"].toString(),
+                    amount = value["amount"].toString(),
+                    toAddress = value["toAddress"].toString(),
+                    fromAddress = value["fromAddress"].toString(),
+                    proxyAddress = value["proxyAddress"]?.toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionFtBurned" -> {
+                EventCollectionFtBurned(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    tokenType = value["tokenType"].toString(),
+                    tokenId = value["tokenId"].toString(),
+                    amount = value["amount"].toString(),
+                    fromAddress = value["fromAddress"].toString(),
+                    proxyAddress = value["proxyAddress"]?.toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionNftIssued" -> {
+                EventCollectionNftIssued(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    tokenType = value["tokenType"].toString(),
+                    issuerAddress = value["issuerAddress"].toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionNftMinted" -> {
+                @Suppress("UNCHECKED_CAST")
+                EventCollectionNftMinted(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    tokenIds = (value["tokenIds"] as List<String>),
+                    toAddress = value["toAddress"].toString(),
+                    minterAddress = value["minterAddress"].toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionNftModified" -> {
+                EventCollectionNftModified(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    tokenId = value["tokenId"].toString(),
+                    tokenAttributes = deserializeCollectionAttributes(value),
+                    modifierAddress = value["modifierAddress"].toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionNftTypeModified" -> {
+                EventCollectionNftTypeModified(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    tokenType = value["tokenType"].toString(),
+                    tokenAttributes = deserializeCollectionAttributes(value),
+                    modifierAddress = value["modifierAddress"].toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionNftAttached" -> {
+                EventCollectionNftAttached(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    childTokenId = value["childTokenId"].toString(),
+                    parentTokenId = value["parentTokenId"].toString(),
+                    holderAddress = value["holderAddress"].toString(),
+                    proxyAddress = value["proxyAddress"]?.toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionNftDetached" -> {
+                EventCollectionNftDetached(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    exChildTokenId = value["exChildTokenId"].toString(),
+                    exParentTokenId = value["exParentTokenId"].toString(),
+                    holderAddress = value["holderAddress"].toString(),
+                    proxyAddress = value["proxyAddress"]?.toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionNftRootChanged" -> {
+                @Suppress("UNCHECKED_CAST")
+                EventCollectionNftRootChanged(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    tokenIds = (value["tokenIds"] as List<String>),
+                    oldRootTokenId = value["oldRootTokenId"].toString(),
+                    newRootTokenId = value["newRootTokenId"].toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionNftHolderChanged" -> {
+                @Suppress("UNCHECKED_CAST")
+                EventCollectionNftHolderChanged(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    tokenIds = (value["tokenIds"] as List<String>),
+                    fromAddress = value["fromAddress"].toString(),
+                    toAddress = value["toAddress"].toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionNftTransferred" -> {
+                @Suppress("UNCHECKED_CAST")
+                EventCollectionNftTransferred(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    tokenIds = (value["tokenIds"] as List<String>),
+                    fromAddress = value["fromAddress"].toString(),
+                    toAddress = value["toAddress"].toString(),
+                    proxyAddress = value["proxyAddress"]?.toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionNftBurned" -> {
+                @Suppress("UNCHECKED_CAST")
+                EventCollectionNftBurned(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    tokenIds = (value["tokenIds"] as List<String>),
+                    fromAddress = value["fromAddress"].toString(),
+                    proxyAddress = value["proxyAddress"]?.toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionPermissionGranted" -> {
+                EventCollectionPermissionGranted(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    permission =  ItemTokenPermission.valueOf(value["permission"].toString()),
+                    granteeAddress = value["granteeAddress"].toString(),
+                    granterAddress = value["granterAddress"]?.toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionPermissionRenounced" -> {
+                EventCollectionPermissionRenounced(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    permission = ItemTokenPermission.valueOf(value["permission"].toString()),
+                    granteeAddress = value["granteeAddress"].toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionProxyApproved" -> {
+                EventCollectionProxyApproved(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    approverAddress = value["approverAddress"].toString(),
+                    proxyAddress = value["proxyAddress"].toString(),
+                )
+            }
+            value["eventName"] == "EventCollectionProxyDisapproved" -> {
+                EventCollectionProxyDisapproved(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    contractId = value["contractId"].toString(),
+                    approverAddress = value["approverAddress"].toString(),
+                    proxyAddress = value["proxyAddress"].toString(),
+                )
+            }
+            else -> {
+                UnknownTransactionEvent(
+                    msgIndex = value["msgIndex"].toString().toInt(),
+                    type = value["type"]?.toString() ?: "",
+                    attributes = emptyList(),
+                    extraMessage = "tx result from response: $value"
+                )
+            }
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun deserializeTokenAttributes(value: Map<Any, Any?>) =
+        (value["tokenAttributes"] as List<Map<String, String>>).map {
+            TokenAttribute(
+                key = it["key"] ?: "",
+                value = it["value"] ?: ""
+            )
+        }.toSet()
+
+    @Suppress("UNCHECKED_CAST")
+    private fun deserializeCollectionAttributes(value: Map<Any, Any?>) =
+        (value["tokenAttributes"] as List<Map<String, String>>).map {
+            CollectionAttribute(
+                key = it["key"] ?: "",
+                value = it["value"] ?: ""
+            )
+        }.toSet()
+}

--- a/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/jackson/TransactionEventDeserializer.kt
+++ b/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/jackson/TransactionEventDeserializer.kt
@@ -67,8 +67,8 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
     override fun deserialize(p: JsonParser, ctxt: DeserializationContext): TransactionEvent {
         val mapTypeReference = object : TypeReference<Map<Any, Any?>>() {}
         val value: Map<Any, Any?> = p.readValueAs(mapTypeReference)
-        return when {
-            value["eventName"] == "EventCoinTransferred" -> {
+        return when(value["eventName"]) {
+            "EventCoinTransferred" -> {
                 EventCoinTransferred(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     denomination = value["denomination"].toString(),
@@ -77,19 +77,19 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     amount = value["amount"].toString(),
                 )
             }
-            value["eventName"] == "EventAccountCreated" -> {
+            "EventAccountCreated" -> {
                 EventAccountCreated(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     createdAddress = value["createdAddress"].toString(),
                 )
             }
-            value["eventName"] == "EventEmptyMsgCreated" -> {
+            "EventEmptyMsgCreated" -> {
                 EventEmptyMsgCreated(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     senderAddress = value["senderAddress"].toString(),
                 )
             }
-            value["eventName"] == "EventTokenBurned" -> {
+            "EventTokenBurned" -> {
                 EventTokenBurned(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -98,7 +98,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     amount = value["amount"].toString(),
                 )
             }
-            value["eventName"] == "EventTokenIssued" -> {
+            "EventTokenIssued" -> {
                 EventTokenIssued(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -110,7 +110,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     amount = value["amount"].toString(),
                 )
             }
-            value["eventName"] == "EventTokenMinted" -> {
+            "EventTokenMinted" -> {
                 EventTokenMinted(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -119,7 +119,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     amount = value["amount"].toString(),
                 )
             }
-            value["eventName"] == "EventTokenTransferred" -> {
+            "EventTokenTransferred" -> {
                 EventTokenTransferred(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -129,7 +129,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     amount = value["amount"].toString(),
                 )
             }
-            value["eventName"] == "EventTokenModified" -> {
+            "EventTokenModified" -> {
                 EventTokenModified(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -137,7 +137,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     tokenAttributes = deserializeTokenAttributes(value)
                 )
             }
-            value["eventName"] == "EventTokenPermissionGranted" -> {
+            "EventTokenPermissionGranted" -> {
                 EventTokenPermissionGranted(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -146,7 +146,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     permission = TokenPermission.valueOf(value["permission"].toString())
                 )
             }
-            value["eventName"] == "EventTokenPermissionRenounced" -> {
+            "EventTokenPermissionRenounced" -> {
                 EventTokenPermissionRenounced(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -154,7 +154,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     permission = TokenPermission.valueOf(value["permission"].toString())
                 )
             }
-            value["eventName"] == "EventTokenProxyApproved" -> {
+            "EventTokenProxyApproved" -> {
                 EventTokenProxyApproved(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -162,7 +162,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     proxyAddress = value["proxyAddress"].toString(),
                 )
             }
-            value["eventName"] == "EventTokenProxyDisapproved" -> {
+            "EventTokenProxyDisapproved" -> {
                 EventTokenProxyDisapproved(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -170,7 +170,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     proxyAddress = value["proxyAddress"].toString(),
                 )
             }
-            value["eventName"] == "EventCollectionCreated" -> {
+            "EventCollectionCreated" -> {
                 EventCollectionCreated(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -178,7 +178,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     creatorAddress = value["creatorAddress"].toString(),
                 )
             }
-            value["eventName"] == "EventCollectionModified" -> {
+            "EventCollectionModified" -> {
                 EventCollectionModified(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -186,7 +186,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     modifierAddress = value["modifierAddress"].toString(),
                 )
             }
-            value["eventName"] == "EventCollectionFtIssued" -> {
+            "EventCollectionFtIssued" -> {
                 EventCollectionFtIssued(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -198,7 +198,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     receiverAddress = value["receiverAddress"].toString(),
                 )
             }
-            value["eventName"] == "EventCollectionFtMinted" -> {
+            "EventCollectionFtMinted" -> {
                 EventCollectionFtMinted(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -209,7 +209,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     minterAddress = value["minterAddress"].toString(),
                 )
             }
-            value["eventName"] == "EventCollectionFtModified" -> {
+            "EventCollectionFtModified" -> {
                 EventCollectionFtModified(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -218,7 +218,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     modifierAddress = value["modifierAddress"].toString(),
                 )
             }
-            value["eventName"] == "EventCollectionFtTransferred" -> {
+            "EventCollectionFtTransferred" -> {
                 EventCollectionFtTransferred(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -230,7 +230,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     proxyAddress = value["proxyAddress"]?.toString(),
                 )
             }
-            value["eventName"] == "EventCollectionFtBurned" -> {
+            "EventCollectionFtBurned" -> {
                 EventCollectionFtBurned(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -241,7 +241,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     proxyAddress = value["proxyAddress"]?.toString(),
                 )
             }
-            value["eventName"] == "EventCollectionNftIssued" -> {
+            "EventCollectionNftIssued" -> {
                 EventCollectionNftIssued(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -249,7 +249,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     issuerAddress = value["issuerAddress"].toString(),
                 )
             }
-            value["eventName"] == "EventCollectionNftMinted" -> {
+            "EventCollectionNftMinted" -> {
                 @Suppress("UNCHECKED_CAST")
                 EventCollectionNftMinted(
                     msgIndex = value["msgIndex"].toString().toInt(),
@@ -259,7 +259,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     minterAddress = value["minterAddress"].toString(),
                 )
             }
-            value["eventName"] == "EventCollectionNftModified" -> {
+            "EventCollectionNftModified" -> {
                 EventCollectionNftModified(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -268,7 +268,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     modifierAddress = value["modifierAddress"].toString(),
                 )
             }
-            value["eventName"] == "EventCollectionNftTypeModified" -> {
+            "EventCollectionNftTypeModified" -> {
                 EventCollectionNftTypeModified(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -277,7 +277,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     modifierAddress = value["modifierAddress"].toString(),
                 )
             }
-            value["eventName"] == "EventCollectionNftAttached" -> {
+            "EventCollectionNftAttached" -> {
                 EventCollectionNftAttached(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -287,7 +287,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     proxyAddress = value["proxyAddress"]?.toString(),
                 )
             }
-            value["eventName"] == "EventCollectionNftDetached" -> {
+            "EventCollectionNftDetached" -> {
                 EventCollectionNftDetached(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -297,7 +297,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     proxyAddress = value["proxyAddress"]?.toString(),
                 )
             }
-            value["eventName"] == "EventCollectionNftRootChanged" -> {
+            "EventCollectionNftRootChanged" -> {
                 @Suppress("UNCHECKED_CAST")
                 EventCollectionNftRootChanged(
                     msgIndex = value["msgIndex"].toString().toInt(),
@@ -307,7 +307,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     newRootTokenId = value["newRootTokenId"].toString(),
                 )
             }
-            value["eventName"] == "EventCollectionNftHolderChanged" -> {
+            "EventCollectionNftHolderChanged" -> {
                 @Suppress("UNCHECKED_CAST")
                 EventCollectionNftHolderChanged(
                     msgIndex = value["msgIndex"].toString().toInt(),
@@ -317,7 +317,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     toAddress = value["toAddress"].toString(),
                 )
             }
-            value["eventName"] == "EventCollectionNftTransferred" -> {
+            "EventCollectionNftTransferred" -> {
                 @Suppress("UNCHECKED_CAST")
                 EventCollectionNftTransferred(
                     msgIndex = value["msgIndex"].toString().toInt(),
@@ -328,7 +328,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     proxyAddress = value["proxyAddress"]?.toString(),
                 )
             }
-            value["eventName"] == "EventCollectionNftBurned" -> {
+            "EventCollectionNftBurned" -> {
                 @Suppress("UNCHECKED_CAST")
                 EventCollectionNftBurned(
                     msgIndex = value["msgIndex"].toString().toInt(),
@@ -338,7 +338,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     proxyAddress = value["proxyAddress"]?.toString(),
                 )
             }
-            value["eventName"] == "EventCollectionPermissionGranted" -> {
+            "EventCollectionPermissionGranted" -> {
                 EventCollectionPermissionGranted(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -347,7 +347,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     granterAddress = value["granterAddress"]?.toString(),
                 )
             }
-            value["eventName"] == "EventCollectionPermissionRenounced" -> {
+            "EventCollectionPermissionRenounced" -> {
                 EventCollectionPermissionRenounced(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -355,7 +355,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     granteeAddress = value["granteeAddress"].toString(),
                 )
             }
-            value["eventName"] == "EventCollectionProxyApproved" -> {
+            "EventCollectionProxyApproved" -> {
                 EventCollectionProxyApproved(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
@@ -363,7 +363,7 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                     proxyAddress = value["proxyAddress"].toString(),
                 )
             }
-            value["eventName"] == "EventCollectionProxyDisapproved" -> {
+            "EventCollectionProxyDisapproved" -> {
                 EventCollectionProxyDisapproved(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),

--- a/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/jackson/TransactionEventDeserializer.kt
+++ b/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/jackson/TransactionEventDeserializer.kt
@@ -138,22 +138,20 @@ class TransactionEventDeserializer : JsonDeserializer<TransactionEvent>() {
                 )
             }
             value["eventName"] == "EventTokenPermissionGranted" -> {
-                val permissionTypeRef = object : TypeReference<TokenPermission>() {}
                 EventTokenPermissionGranted(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
                     granteeAddress = value["granteeAddress"].toString(),
                     granterAddress = value["granterAddress"].toString(),
-                    permission = p.readValueAs(permissionTypeRef)
+                    permission = TokenPermission.valueOf(value["permission"].toString())
                 )
             }
             value["eventName"] == "EventTokenPermissionRenounced" -> {
-                val permissionTypeRef = object : TypeReference<TokenPermission>() {}
                 EventTokenPermissionRenounced(
                     msgIndex = value["msgIndex"].toString().toInt(),
                     contractId = value["contractId"].toString(),
                     granteeAddress = value["granteeAddress"].toString(),
-                    permission = p.readValueAs(permissionTypeRef)
+                    permission = TokenPermission.valueOf(value["permission"].toString())
                 )
             }
             value["eventName"] == "EventTokenProxyApproved" -> {

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/jackson/TransactionEventDeserializerTest.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/jackson/TransactionEventDeserializerTest.kt
@@ -22,9 +22,21 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.linecorp.link.developers.txresult.core.event.bank.EventCoinTransferred
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionFtBurned
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionFtIssued
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionFtMinted
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionFtModified
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionFtTransferred
 import com.linecorp.link.developers.txresult.core.event.item.EventCollectionModified
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionNftMinted
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionNftTransferred
+import com.linecorp.link.developers.txresult.core.event.token.EventTokenBurned
 import com.linecorp.link.developers.txresult.core.event.token.EventTokenIssued
+import com.linecorp.link.developers.txresult.core.event.token.EventTokenMinted
 import com.linecorp.link.developers.txresult.core.event.token.EventTokenModified
+import com.linecorp.link.developers.txresult.core.event.token.EventTokenProxyApproved
+import com.linecorp.link.developers.txresult.core.event.token.EventTokenTransferred
 import com.linecorp.link.developers.txresult.core.model.TransactionEvent
 import com.linecorp.link.developers.txresult.core.model.TxResult
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -49,9 +61,93 @@ class TransactionEventDeserializerTest {
     }
 
     @Test
+    fun `events from updating item token collection tx-result`() {
+        val typeReference = object : TypeReference<TxResult>() {}
+        val inputStream =
+            this::class.java.classLoader.getResourceAsStream("./txresults/update-item-token-collection-txresult.json")
+        val actual = objectMapper.readValue(inputStream, typeReference)
+        assertTrue(actual.events.any { it is EventCollectionModified })
+    }
+
+    @Test
+    fun `events from minting item token collection tx-result`() {
+        val typeReference = object : TypeReference<TxResult>() {}
+        val inputStream = this::class.java.classLoader.getResourceAsStream("./txresults/mint-nft-txresult.json")
+        val actual = objectMapper.readValue(inputStream, typeReference)
+        assertTrue(actual.events.any { it is EventCollectionNftMinted })
+        val eventCollectionNftMinted = actual.events.filterIsInstance<EventCollectionNftMinted>().first()
+        assertTrue(eventCollectionNftMinted.tokenIds.isNotEmpty())
+    }
+
+    @Test
+    fun `events from issuing item token ft tx-result`() {
+        val typeReference = object : TypeReference<TxResult>() {}
+        val inputStream = this::class.java.classLoader.getResourceAsStream("./txresults/issue-ft-txresult.json")
+        val actual = objectMapper.readValue(inputStream, typeReference)
+        assertTrue(actual.events.any { it is EventCollectionFtIssued })
+    }
+
+    @Test
+    fun `events from minting item token ft tx-result`() {
+        val typeReference = object : TypeReference<TxResult>() {}
+        val inputStream = this::class.java.classLoader.getResourceAsStream("./txresults/mint-ft-txresult.json")
+        val actual = objectMapper.readValue(inputStream, typeReference)
+        assertTrue(actual.events.any { it is EventCollectionFtMinted })
+    }
+
+    @Test
+    fun `events from burning item token ft tx-result`() {
+        val typeReference = object : TypeReference<TxResult>() {}
+        val inputStream = this::class.java.classLoader.getResourceAsStream("./txresults/burn-ft-txresult.json")
+        val actual = objectMapper.readValue(inputStream, typeReference)
+        assertTrue(actual.events.any { it is EventCollectionFtBurned })
+    }
+
+    @Test
+    fun `events from transferring item token ft tx-result`() {
+        val typeReference = object : TypeReference<TxResult>() {}
+        val inputStream = this::class.java.classLoader.getResourceAsStream("./txresults/transfer-ft-txresult.json")
+        val actual = objectMapper.readValue(inputStream, typeReference)
+        assertTrue(actual.events.any { it is EventCollectionFtTransferred })
+    }
+
+    @Test
+    fun `events from updating item token ft tx-result`() {
+        val typeReference = object : TypeReference<TxResult>() {}
+        val inputStream = this::class.java.classLoader.getResourceAsStream("./txresults/update-ft-txresult.json")
+        val actual = objectMapper.readValue(inputStream, typeReference)
+        assertTrue(actual.events.any { it is EventCollectionFtModified })
+    }
+
+
+    @Test
+    fun `events from minting and transferring item token collection tx-result`() {
+        val typeReference = object : TypeReference<TxResult>() {}
+        val inputStream =
+            this::class.java.classLoader.getResourceAsStream("./txresults/mint-transfer-nft-txresult.json")
+        val actual = objectMapper.readValue(inputStream, typeReference)
+        assertTrue(actual.events.any { it is EventCollectionNftMinted })
+        assertTrue(actual.events.any { it is EventCollectionNftTransferred })
+        val eventCollectionNftMinted = actual.events.filterIsInstance<EventCollectionNftMinted>().first()
+        assertTrue(eventCollectionNftMinted.tokenIds.isNotEmpty())
+        val eventCollectionNftTransferred = actual.events.filterIsInstance<EventCollectionNftTransferred>().first()
+        assertTrue(eventCollectionNftTransferred.tokenIds.isNotEmpty())
+    }
+
+    @Test
+    fun `events from transferring base-coin tx-result`() {
+        val typeReference = object : TypeReference<TxResult>() {}
+        val inputStream =
+            this::class.java.classLoader.getResourceAsStream("./txresults/tranfer-base-coin-txresult.json")
+        val actual = objectMapper.readValue(inputStream, typeReference)
+        assertTrue(actual.events.any { it is EventCoinTransferred })
+    }
+
+    @Test
     fun `events from issuing service token tx-result`() {
         val typeReference = object : TypeReference<TxResult>() {}
-        val inputStream = this::class.java.classLoader.getResourceAsStream("./txresults/create-service-token-txresult.json")
+        val inputStream =
+            this::class.java.classLoader.getResourceAsStream("./txresults/create-service-token-txresult.json")
         val actual = objectMapper.readValue(inputStream, typeReference)
         assertTrue(actual.events.any { it is EventTokenIssued })
     }
@@ -59,17 +155,50 @@ class TransactionEventDeserializerTest {
     @Test
     fun `events from updating service token tx-result`() {
         val typeReference = object : TypeReference<TxResult>() {}
-        val inputStream = this::class.java.classLoader.getResourceAsStream("./txresults/update-service-token-txresult.json")
+        val inputStream =
+            this::class.java.classLoader.getResourceAsStream("./txresults/update-service-token-txresult.json")
         val actual = objectMapper.readValue(inputStream, typeReference)
         assertTrue(actual.events.any { it is EventTokenModified })
     }
 
     @Test
-    fun `events from updating item token collection tx-result`() {
+    fun `events from burning service token tx-result`() {
         val typeReference = object : TypeReference<TxResult>() {}
-        val inputStream = this::class.java.classLoader.getResourceAsStream("./txresults/update-item-token-collection-txresult.json")
+        val inputStream =
+            this::class.java.classLoader.getResourceAsStream("./txresults/burn-service-token-txresult.json")
         val actual = objectMapper.readValue(inputStream, typeReference)
-        assertTrue(actual.events.any { it is EventCollectionModified })
+        assertTrue(actual.events.any { it is EventTokenBurned })
+    }
+
+    @Test
+    fun `events from minting service token tx-result`() {
+        val typeReference = object : TypeReference<TxResult>() {}
+        val inputStream =
+            this::class.java.classLoader.getResourceAsStream("./txresults/mint-service-token-txresult.json")
+        val actual = objectMapper.readValue(inputStream, typeReference)
+        assertTrue(actual.events.any { it is EventTokenMinted })
+    }
+
+    @Test
+    fun `events from transferFrom service token tx-result`() {
+        val typeReference = object : TypeReference<TxResult>() {}
+        val inputStream =
+            this::class.java.classLoader.getResourceAsStream("./txresults/transfer-from-service-token-txresult.json")
+        val actual = objectMapper.readValue(inputStream, typeReference)
+        assertTrue(actual.events.any { it is EventTokenTransferred })
+        val eventCoinTransferred = actual.events.filterIsInstance<EventTokenTransferred>().first()
+        assertTrue(eventCoinTransferred.proxyAddress?.isNotBlank() ?: false)
+    }
+
+    @Test
+    fun `events from approve proxy for service token tx-result`() {
+        val typeReference = object : TypeReference<TxResult>() {}
+        val inputStream =
+            this::class.java.classLoader.getResourceAsStream("./txresults/approve-proxy-service-token-txresult.json")
+        val actual = objectMapper.readValue(inputStream, typeReference)
+        assertTrue(actual.events.any { it is EventTokenProxyApproved })
+        val eventCoinTransferred = actual.events.filterIsInstance<EventTokenProxyApproved>().first()
+        assertTrue(eventCoinTransferred.proxyAddress?.isNotBlank() ?: false)
     }
 
 }

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/jackson/TransactionEventDeserializerTest.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/jackson/TransactionEventDeserializerTest.kt
@@ -1,0 +1,75 @@
+/*
+ *   Copyright 2023 LINE Corporation
+ *
+ *   LINE Corporation licenses this file to you under the Apache License,
+ *   version 2.0 (the "License"); you may not use this file except in compliance
+ *   with the License. You may obtain a copy of the License at:
+ *
+ *     https:www.apache.orglicensesLICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *   License for the specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+
+package com.linecorp.link.developers.jackson
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.linecorp.link.developers.txresult.core.event.item.EventCollectionModified
+import com.linecorp.link.developers.txresult.core.event.token.EventTokenIssued
+import com.linecorp.link.developers.txresult.core.event.token.EventTokenModified
+import com.linecorp.link.developers.txresult.core.model.TransactionEvent
+import com.linecorp.link.developers.txresult.core.model.TxResult
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class TransactionEventDeserializerTest {
+    private lateinit var underTest: TransactionEventDeserializer
+
+    private lateinit var objectMapper: ObjectMapper
+
+    @BeforeEach
+    fun setUp() {
+        underTest = TransactionEventDeserializer()
+        objectMapper = jacksonObjectMapper()
+        val simpleModule = SimpleModule().addDeserializer(
+            TransactionEvent::class.java,
+            underTest
+        )
+        objectMapper.registerModule(simpleModule)
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    }
+
+    @Test
+    fun `events from issuing service token tx-result`() {
+        val typeReference = object : TypeReference<TxResult>() {}
+        val inputStream = this::class.java.classLoader.getResourceAsStream("./txresults/create-service-token-txresult.json")
+        val actual = objectMapper.readValue(inputStream, typeReference)
+        assertTrue(actual.events.any { it is EventTokenIssued })
+    }
+
+    @Test
+    fun `events from updating service token tx-result`() {
+        val typeReference = object : TypeReference<TxResult>() {}
+        val inputStream = this::class.java.classLoader.getResourceAsStream("./txresults/update-service-token-txresult.json")
+        val actual = objectMapper.readValue(inputStream, typeReference)
+        assertTrue(actual.events.any { it is EventTokenModified })
+    }
+
+    @Test
+    fun `events from updating item token collection tx-result`() {
+        val typeReference = object : TypeReference<TxResult>() {}
+        val inputStream = this::class.java.classLoader.getResourceAsStream("./txresults/update-item-token-collection-txresult.json")
+        val actual = objectMapper.readValue(inputStream, typeReference)
+        assertTrue(actual.events.any { it is EventCollectionModified })
+    }
+
+}

--- a/libs/developers-tx-result-adapter/src/test/resources/txresults/approve-proxy-service-token-txresult.json
+++ b/libs/developers-tx-result-adapter/src/test/resources/txresults/approve-proxy-service-token-txresult.json
@@ -1,0 +1,38 @@
+{
+  "summary": {
+    "height": 1207317,
+    "txHash": "2C981A65B9A2F4DF6EC8CC5E084905A9C2C8488F7E533C9F71394F254D76F039",
+    "txIndex": 0,
+    "timestamp": 1618370726000,
+    "signers": [
+      {
+        "address": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq"
+      }
+    ],
+    "result": {
+      "code": 0,
+      "codeSpace": "",
+      "status": "SUCCEEDED"
+    }
+  },
+  "messages": [
+    {
+      "msgIndex": 0,
+      "requestType": "token/MsgApprove",
+      "details": {
+        "approver":"link1j8jd9nps56txm2w3afcjsktrrjh0ft82eftchd",
+        "contractId":"f38bb8a6",
+        "proxy":"link1he0tp59u36mdjaw560gh8c27pz8fqms88l8nhu"
+      }
+    }
+  ],
+  "events": [
+    {
+      "eventName": "EventTokenProxyApproved",
+      "msgIndex": 0,
+      "contractId": "9636a07e",
+      "approverAddress": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+      "proxyAddress": "tlink1xrr7amq5g80afllmfcud59y3w60q58llx2zpe9"
+    }
+  ]
+}

--- a/libs/developers-tx-result-adapter/src/test/resources/txresults/burn-ft-txresult.json
+++ b/libs/developers-tx-result-adapter/src/test/resources/txresults/burn-ft-txresult.json
@@ -1,0 +1,46 @@
+{
+  "summary": {
+    "height": 1207317,
+    "txHash": "2C981A65B9A2F4DF6EC8CC5E084905A9C2C8488F7E533C9F71394F254D76F039",
+    "txIndex": 0,
+    "timestamp": 1618370726000,
+    "signers": [
+      {
+        "address": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq"
+      }
+    ],
+    "result": {
+      "code": 0,
+      "codeSpace": "",
+      "status": "SUCCEEDED"
+    }
+  },
+  "messages": [
+    {
+      "msgIndex": 0,
+      "requestType": "collection/MsgBurnFT",
+      "details": {
+        "from": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+        "contractId": "61e14383",
+        "amount": [
+          {
+            "tokenId": "0000000100000000",
+            "amount": 1
+          }
+        ]
+      }
+    }
+  ],
+  "events": [
+    {
+      "eventName": "EventCollectionFtBurned",
+      "msgIndex": 0,
+      "contractId": "61e14383",
+      "tokenId": "0000000100000000",
+      "amount": "1",
+      "fromAddress": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+      "proxyAddress": "",
+      "tokenType": "00000001"
+    }
+  ]
+}

--- a/libs/developers-tx-result-adapter/src/test/resources/txresults/burn-service-token-txresult.json
+++ b/libs/developers-tx-result-adapter/src/test/resources/txresults/burn-service-token-txresult.json
@@ -1,0 +1,39 @@
+{
+  "summary": {
+    "height": 1207317,
+    "txHash": "2C981A65B9A2F4DF6EC8CC5E084905A9C2C8488F7E533C9F71394F254D76F039",
+    "txIndex": 0,
+    "timestamp": 1618370726000,
+    "signers": [
+      {
+        "address": "tlink1xrr7amq5g80afllmfcud59y3w60q58llx2zpe9"
+      }
+    ],
+    "result": {
+      "code": 0,
+      "codeSpace": "",
+      "status": "SUCCEEDED"
+    }
+  },
+  "messages": [
+    {
+      "msgIndex": 0,
+      "requestType": "token/MsgBurn",
+      "details": {
+        "from": "tlink1xrr7amq5g80afllmfcud59y3w60q58llx2zpe9",
+        "contractId": "9be17165",
+        "amount": 1000
+      }
+    }
+  ],
+  "events": [
+    {
+      "eventName": "EventTokenBurned",
+      "msgIndex": 0,
+      "contractId": "9be17165",
+      "amount": "1000",
+      "fromAddress": "tlink1xrr7amq5g80afllmfcud59y3w60q58llx2zpe9",
+      "proxyAddress": ""
+    }
+  ]
+}

--- a/libs/developers-tx-result-adapter/src/test/resources/txresults/create-service-token-txresult.json
+++ b/libs/developers-tx-result-adapter/src/test/resources/txresults/create-service-token-txresult.json
@@ -1,0 +1,48 @@
+{
+  "summary":{
+    "height":1207317,
+    "txHash":"2C981A65B9A2F4DF6EC8CC5E084905A9C2C8488F7E533C9F71394F254D76F039",
+    "txIndex":0,
+    "timestamp":1618370726000,
+    "signers":[
+      {
+        "address": "tlink1n9pqyk4jy8d3pd20quryudxw3g47cl99403558"
+      }
+    ],
+    "result":{
+      "code":0,
+      "codeSpace":"",
+      "status":"SUCCEEDED"
+    }
+  },
+  "messages":[
+    {
+      "msgIndex":0,
+      "requestType":"token/MsgIssue",
+      "details":{
+        "owner":"tlink1n9pqyk4jy8d3pd20quryudxw3g47cl99403558",
+        "to":"tlink1n9pqyk4jy8d3pd20quryudxw3g47cl99403558",
+        "name":"Test",
+        "meta":"",
+        "symbol":"TEST",
+        "imgUri":"https://service-token.com/image/token",
+        "amount":"987654321",
+        "mintable":true,
+        "decimals":"6"
+      }
+    }
+  ],
+  "events":[
+    {
+      "eventName": "EventTokenIssued",
+      "msgIndex": 0,
+      "contractId":"9be17165",
+      "issuerAddress":"tlink1n9pqyk4jy8d3pd20quryudxw3g47cl99403558",
+      "receiverAddress":"tlink1n9pqyk4jy8d3pd20quryudxw3g47cl99403558",
+      "name":"Test",
+      "symbol":"TEST",
+      "decimals":6,
+      "amount":"987654321"
+    }
+  ]
+}

--- a/libs/developers-tx-result-adapter/src/test/resources/txresults/issue-ft-txresult.json
+++ b/libs/developers-tx-result-adapter/src/test/resources/txresults/issue-ft-txresult.json
@@ -1,0 +1,43 @@
+{
+  "summary": {
+    "height": 1207317,
+    "txHash": "2C981A65B9A2F4DF6EC8CC5E084905A9C2C8488F7E533C9F71394F254D76F039",
+    "txIndex": 0,
+    "timestamp": 1618370726000,
+    "signers": [
+      {
+        "address": "link17k4j8nfr47urlzfz6h7hzdaankpkz0dgce0xkz"
+      }
+    ],
+    "result": {
+      "code": 0,
+      "codeSpace": "",
+      "status": "SUCCEEDED"
+    }
+  },
+  "messages": [
+    {
+      "msgIndex": 0,
+      "requestType": "collection/MsgIssueFT",
+      "details": {
+        "owner": "link17k4j8nfr47urlzfz6h7hzdaankpkz0dgce0xkz",
+        "name": "test",
+        "meta": "",
+        "base_img_uri": "http://test-image-server.com"
+      }
+    }
+  ],
+  "events": [
+    {
+      "eventName": "EventCollectionFtIssued",
+      "msgIndex": 0,
+      "contractId": "61e14383",
+      "tokenType": "0000003100000000",
+      "name": "FungibleName",
+      "amount": "0",
+      "decimals": 0,
+      "issuerAddress": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+      "receiverAddress": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq"
+    }
+  ]
+}

--- a/libs/developers-tx-result-adapter/src/test/resources/txresults/mint-ft-txresult.json
+++ b/libs/developers-tx-result-adapter/src/test/resources/txresults/mint-ft-txresult.json
@@ -1,0 +1,47 @@
+{
+  "summary": {
+    "height": 1207317,
+    "txHash": "2C981A65B9A2F4DF6EC8CC5E084905A9C2C8488F7E533C9F71394F254D76F039",
+    "txIndex": 0,
+    "timestamp": 1618370726000,
+    "signers": [
+      {
+        "address": "link153tnef6fp2w95ny00cegj6pfyvsqcsy2dkv6lt"
+      }
+    ],
+    "result": {
+      "code": 0,
+      "codeSpace": "",
+      "status": "SUCCEEDED"
+    }
+  },
+  "messages": [
+    {
+      "msgIndex": 0,
+      "requestType": "collection/MsgMintFT",
+      "details": {
+        "from": "link153tnef6fp2w95ny00cegj6pfyvsqcsy2dkv6lt",
+        "contract_id": "d036ce60",
+        "to": "link153tnef6fp2w95ny00cegj6pfyvsqcsy2dkv6lt",
+        "amount": [
+          {
+            "token_id": "0000000100000000",
+            "amount": "10000"
+          }
+        ]
+      }
+    }
+  ],
+  "events": [
+    {
+      "eventName": "EventCollectionFtMinted",
+      "msgIndex": 0,
+      "contractId": "d036ce60",
+      "tokenId": "0000000100000000",
+      "amount": "10000",
+      "toAddress": "link153tnef6fp2w95ny00cegj6pfyvsqcsy2dkv6lt",
+      "minterAddress": "link153tnef6fp2w95ny00cegj6pfyvsqcsy2dkv6lt",
+      "tokenType": "00000001"
+    }
+  ]
+}

--- a/libs/developers-tx-result-adapter/src/test/resources/txresults/mint-nft-txresult.json
+++ b/libs/developers-tx-result-adapter/src/test/resources/txresults/mint-nft-txresult.json
@@ -1,0 +1,48 @@
+{
+  "summary": {
+    "height": 1207317,
+    "txHash": "2C981A65B9A2F4DF6EC8CC5E084905A9C2C8488F7E533C9F71394F254D76F039",
+    "txIndex": 0,
+    "timestamp": 1618370726000,
+    "signers": [
+      {
+        "address": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq"
+      }
+    ],
+    "result": {
+      "code": 0,
+      "codeSpace": "",
+      "status": "SUCCEEDED"
+    }
+  },
+  "messages": [
+    {
+      "msgIndex": 0,
+      "requestType": "collection/MsgMintNFT",
+      "details": {
+        "from": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+        "contractId": "61e14383",
+        "to": "tlink12v6t8c3reucj3ahfvx9tvghpltwchh7uvj5frl",
+        "params": [
+          {
+            "name": "NFT index name",
+            "meta": "NFT index meta",
+            "tokenType": "10000001"
+          }
+        ]
+      }
+    }
+  ],
+  "events": [
+    {
+      "eventName": "EventCollectionNftMinted",
+      "msgIndex": 0,
+      "contractId": "61e14383",
+      "tokenIds": [
+        "1000000100000007"
+      ],
+      "toAddress": "tlink12v6t8c3reucj3ahfvx9tvghpltwchh7uvj5frl",
+      "minterAddress": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq"
+    }
+  ]
+}

--- a/libs/developers-tx-result-adapter/src/test/resources/txresults/mint-service-token-txresult.json
+++ b/libs/developers-tx-result-adapter/src/test/resources/txresults/mint-service-token-txresult.json
@@ -1,0 +1,40 @@
+{
+  "summary": {
+    "height": 1207317,
+    "txHash": "2C981A65B9A2F4DF6EC8CC5E084905A9C2C8488F7E533C9F71394F254D76F039",
+    "txIndex": 0,
+    "timestamp": 1618370726000,
+    "signers": [
+      {
+        "address": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq"
+      }
+    ],
+    "result": {
+      "code": 0,
+      "codeSpace": "",
+      "status": "SUCCEEDED"
+    }
+  },
+  "messages": [
+    {
+      "msgIndex": 0,
+      "requestType": "token/MsgMint",
+      "details": {
+        "from": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+        "contractId": "9636a07e",
+        "to": "tlink1nf5uhdmtsshmkqvlmq45kn4q9atnkx4l3u4rww",
+        "amount": 1000
+      }
+    }
+  ],
+  "events": [
+    {
+      "eventName": "EventTokenMinted",
+      "msgIndex": 0,
+      "contractId": "9636a07e",
+      "amount": "1000",
+      "minterAddress": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+      "toAddress": "tlink1nf5uhdmtsshmkqvlmq45kn4q9atnkx4l3u4rww"
+    }
+  ]
+}

--- a/libs/developers-tx-result-adapter/src/test/resources/txresults/mint-transfer-nft-txresult.json
+++ b/libs/developers-tx-result-adapter/src/test/resources/txresults/mint-transfer-nft-txresult.json
@@ -1,0 +1,73 @@
+{
+  "summary": {
+    "height": 1207317,
+    "txHash": "2C981A65B9A2F4DF6EC8CC5E084905A9C2C8488F7E533C9F71394F254D76F039",
+    "txIndex": 0,
+    "timestamp": 1618370726000,
+    "signers": [
+      {
+        "address": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq"
+      }
+    ],
+    "result": {
+      "code": 0,
+      "codeSpace": "",
+      "status": "SUCCEEDED"
+    }
+  },
+  "messages": [
+    {
+      "msgIndex": 0,
+      "requestType": "collection/MsgMintNFT",
+      "details": {
+        "from": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+        "contractId": "61e14383",
+        "to": "tlink12v6t8c3reucj3ahfvx9tvghpltwchh7uvj5frl",
+        "params": [
+          {
+            "name": "NFT index name",
+            "meta": "NFT index meta",
+            "tokenType": "10000001"
+          }
+        ]
+      }
+    },
+    {
+      "msgIndex":1,
+      "requestType":"collection/MsgTransferNFTFrom",
+      "details":{
+        "proxy":"link1he0tp59u36mdjaw560gh8c27pz8fqms88l8nhu",
+        "from":"link153tnef6fp2w95ny00cegj6pfyvsqcsy2dkv6lt",
+        "contract_id":"d036ce60",
+        "to":"link1rrjua8zktmqnr6hlsqz7qyx5gxm5z96yt8f5ae",
+        "token_ids":[
+          "1000000100000001"
+        ]
+      }
+    }
+
+  ],
+  "events": [
+    {
+      "eventName": "EventCollectionNftMinted",
+      "msgIndex": 0,
+      "contractId": "61e14383",
+      "tokenIds": [
+        "1000000100000007"
+      ],
+      "toAddress": "tlink12v6t8c3reucj3ahfvx9tvghpltwchh7uvj5frl",
+      "minterAddress": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq"
+    },
+    {
+      "eventName": "EventCollectionNftTransferred",
+      "msgIndex": 1,
+      "contractId":"d036ce60",
+      "tokenIds":[
+        "1000000100000001"
+      ],
+      "fromAddress":"link153tnef6fp2w95ny00cegj6pfyvsqcsy2dkv6lt",
+      "toAddress":"link1rrjua8zktmqnr6hlsqz7qyx5gxm5z96yt8f5ae",
+      "proxyAddress":"link1he0tp59u36mdjaw560gh8c27pz8fqms88l8nhu"
+    }
+  ]
+}

--- a/libs/developers-tx-result-adapter/src/test/resources/txresults/tranfer-base-coin-txresult.json
+++ b/libs/developers-tx-result-adapter/src/test/resources/txresults/tranfer-base-coin-txresult.json
@@ -1,0 +1,44 @@
+{
+  "summary": {
+    "height": 1207317,
+    "txHash": "2C981A65B9A2F4DF6EC8CC5E084905A9C2C8488F7E533C9F71394F254D76F039",
+    "txIndex": 0,
+    "timestamp": 1618370726000,
+    "signers": [
+      {
+        "address": "tlink1xrr7amq5g80afllmfcud59y3w60q58llx2zpe9"
+      }
+    ],
+    "result": {
+      "code": 0,
+      "codeSpace": "",
+      "status": "SUCCEEDED"
+    }
+  },
+  "messages": [
+    {
+      "msgIndex": 0,
+      "requestType": "coin/MsgSend",
+      "details": {
+        "from": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+        "to": "tlink1nf5uhdmtsshmkqvlmq45kn4q9atnkx4l3u4rww",
+        "amount": [
+          {
+            "denom": "tcony",
+            "amount": 1
+          }
+        ]
+      }
+    }
+  ],
+  "events": [
+    {
+      "eventName": "EventCoinTransferred",
+      "msgIndex": 0,
+      "denomination": "tcony",
+      "amount": "1000",
+      "fromAddress": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+      "toAddress": "tlink1nf5uhdmtsshmkqvlmq45kn4q9atnkx4l3u4rww"
+    }
+  ]
+}

--- a/libs/developers-tx-result-adapter/src/test/resources/txresults/transfer-from-service-token-txresult.json
+++ b/libs/developers-tx-result-adapter/src/test/resources/txresults/transfer-from-service-token-txresult.json
@@ -1,0 +1,42 @@
+{
+  "summary": {
+    "height": 1207317,
+    "txHash": "2C981A65B9A2F4DF6EC8CC5E084905A9C2C8488F7E533C9F71394F254D76F039",
+    "txIndex": 0,
+    "timestamp": 1618370726000,
+    "signers": [
+      {
+        "address": "tlink1xrr7amq5g80afllmfcud59y3w60q58llx2zpe9"
+      }
+    ],
+    "result": {
+      "code": 0,
+      "codeSpace": "",
+      "status": "SUCCEEDED"
+    }
+  },
+  "messages": [
+    {
+      "msgIndex": 0,
+      "requestType": "token/MsgTransferFrom",
+      "details": {
+        "proxyAddress": "tlink1xrr7amq5g80afllmfcud59y3w60q58llx2zpe9",
+        "from": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+        "contractId": "9636a07e",
+        "to": "tlink1nf5uhdmtsshmkqvlmq45kn4q9atnkx4l3u4rww",
+        "amount": 1000
+      }
+    }
+  ],
+  "events": [
+    {
+      "eventName": "EventTokenTransferred",
+      "msgIndex": 0,
+      "contractId": "9636a07e",
+      "amount": "1000",
+      "fromAddress": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+      "toAddress": "tlink1nf5uhdmtsshmkqvlmq45kn4q9atnkx4l3u4rww",
+      "proxyAddress": "tlink1xrr7amq5g80afllmfcud59y3w60q58llx2zpe9"
+    }
+  ]
+}

--- a/libs/developers-tx-result-adapter/src/test/resources/txresults/transfer-ft-txresult.json
+++ b/libs/developers-tx-result-adapter/src/test/resources/txresults/transfer-ft-txresult.json
@@ -1,0 +1,48 @@
+{
+  "summary": {
+    "height": 1207317,
+    "txHash": "2C981A65B9A2F4DF6EC8CC5E084905A9C2C8488F7E533C9F71394F254D76F039",
+    "txIndex": 0,
+    "timestamp": 1618370726000,
+    "signers": [
+      {
+        "address": "link153tnef6fp2w95ny00cegj6pfyvsqcsy2dkv6lt"
+      }
+    ],
+    "result": {
+      "code": 0,
+      "codeSpace": "",
+      "status": "SUCCEEDED"
+    }
+  },
+  "messages": [
+    {
+      "msgIndex": 0,
+      "requestType": "collection/MsgTransferFT",
+      "details": {
+        "from": "link153tnef6fp2w95ny00cegj6pfyvsqcsy2dkv6lt",
+        "contract_id": "d036ce60",
+        "to": "link1rrjua8zktmqnr6hlsqz7qyx5gxm5z96yt8f5ae",
+        "amount": [
+          {
+            "token_id": "0000000100000000",
+            "amount": "10"
+          }
+        ]
+      }
+    }
+  ],
+  "events": [
+    {
+      "eventName": "EventCollectionFtTransferred",
+      "msgIndex": 0,
+      "contractId": "d036ce60",
+      "tokenId": "0000000100000000",
+      "amount": "10",
+      "fromAddress": "link153tnef6fp2w95ny00cegj6pfyvsqcsy2dkv6lt",
+      "toAddress": "link1rrjua8zktmqnr6hlsqz7qyx5gxm5z96yt8f5ae",
+      "proxyAddress": "",
+      "tokenType": "00000001"
+    }
+  ]
+}

--- a/libs/developers-tx-result-adapter/src/test/resources/txresults/update-ft-txresult.json
+++ b/libs/developers-tx-result-adapter/src/test/resources/txresults/update-ft-txresult.json
@@ -1,0 +1,50 @@
+{
+  "summary": {
+    "height": 1207317,
+    "txHash": "2C981A65B9A2F4DF6EC8CC5E084905A9C2C8488F7E533C9F71394F254D76F039",
+    "txIndex": 0,
+    "timestamp": 1618370726000,
+    "signers": [
+      {
+        "address": "link153tnef6fp2w95ny00cegj6pfyvsqcsy2dkv6lt"
+      }
+    ],
+    "result": {
+      "code": 0,
+      "codeSpace": "",
+      "status": "SUCCEEDED"
+    }
+  },
+  "messages": [
+    {
+      "msgIndex": 0,
+      "requestType": "collection/MsgModify",
+      "details": {
+        "owner": "link153tnef6fp2w95ny00cegj6pfyvsqcsy2dkv6lt",
+        "contract_id": "d036ce60",
+        "token_type": "00000001",
+        "token_index": "00000000",
+        "changes": [
+          {
+            "field": "name",
+            "value": "FTTEST1"
+          }
+        ]
+      }
+    }
+  ],
+  "events": [
+    {
+      "eventName": "EventCollectionFtModified",
+      "msgIndex": 0,
+      "contractId": "d036ce60",
+      "tokenAttributes": [
+        {
+          "key": "name",
+          "value": "FTTEST1"
+        }
+      ],
+      "modifierAddress": "link153tnef6fp2w95ny00cegj6pfyvsqcsy2dkv6lt"
+    }
+  ]
+}

--- a/libs/developers-tx-result-adapter/src/test/resources/txresults/update-item-token-collection-txresult.json
+++ b/libs/developers-tx-result-adapter/src/test/resources/txresults/update-item-token-collection-txresult.json
@@ -1,0 +1,58 @@
+{
+  "summary":{
+    "height":1207317,
+    "txHash":"2C981A65B9A2F4DF6EC8CC5E084905A9C2C8488F7E533C9F71394F254D76F039",
+    "txIndex":0,
+    "timestamp":1618370726000,
+    "signers":[
+      {
+        "address": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq"
+      }
+    ],
+    "result":{
+      "code":0,
+      "codeSpace":"",
+      "status":"SUCCEEDED"
+    }
+  },
+  "messages":[
+    {
+      "msgIndex":0,
+      "requestType":"collection/MsgModify",
+      "details":{
+        "owner":"tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+        "contractId":"61e14383",
+        "tokenType":"10000001",
+        "tokenIndex":"",
+        "changes":[
+          {
+            "field":"name",
+            "value":"NFT Name"
+          },
+          {
+            "field":"meta",
+            "value":"NFT meta"
+          }
+        ]
+      }
+    }
+  ],
+  "events":[
+    {
+      "eventName": "EventCollectionModified",
+      "msgIndex": 0,
+      "contractId":"61e14383",
+      "tokenAttributes":[
+        {
+          "key":"meta",
+          "value":"NFT meta"
+        },
+        {
+          "key":"name",
+          "value":"NFT Name"
+        }
+      ],
+      "modifierAddress":"tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq"
+    }
+  ]
+}

--- a/libs/developers-tx-result-adapter/src/test/resources/txresults/update-service-token-txresult.json
+++ b/libs/developers-tx-result-adapter/src/test/resources/txresults/update-service-token-txresult.json
@@ -1,0 +1,56 @@
+{
+  "summary":{
+    "height":1207317,
+    "txHash":"2C981A65B9A2F4DF6EC8CC5E084905A9C2C8488F7E533C9F71394F254D76F039",
+    "txIndex":0,
+    "timestamp":1618370726000,
+    "signers":[
+      {
+        "address": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq"
+      }
+    ],
+    "result":{
+      "code":0,
+      "codeSpace":"",
+      "status":"SUCCEEDED"
+    }
+  },
+  "messages":[
+    {
+      "msgIndex":0,
+      "requestType":"token/MsgModify",
+      "details":{
+        "owner":"tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+        "contractId":"9636a07e",
+        "changes":[
+          {
+            "field":"name",
+            "value":"Test"
+          },
+          {
+            "field":"meta",
+            "value":"meta"
+          }
+        ]
+      }
+    }
+  ],
+  "events":[
+    {
+      "eventName": "EventTokenModified",
+      "msgIndex": 0,
+      "contractId":"9636a07e",
+      "modifierAddress":"tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+      "tokenAttributes":[
+        {
+          "key":"name",
+          "value":"Test"
+        },
+        {
+          "key":"meta",
+          "value": "test"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### What kind of change does this PR introduce?
* [ ] bug fix
* [x] feature
* [ ] docs
* [ ] update

### What is the current behavior?
No proper way to deserialize `TransactionEvent` sub-types, which is concrete event

### What is the new behavior?
It look a kind of brute force way, but I guess it is easy and effective
