### PR TITLE
fix: replace set to list for events

### DIFF
--- a/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientBasicTest.kt
+++ b/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientBasicTest.kt
@@ -54,7 +54,6 @@ class ApiClientBasicTest {
             enableLogging = true,
             apiKeySecret = apiKeySecret
         )
-        val now = clock.instant().toEpochMilli()
 
         val timeResponse = runBlocking {
             delay(1000)

--- a/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientBasicTest.kt
+++ b/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientBasicTest.kt
@@ -39,8 +39,6 @@ class ApiClientBasicTest {
     private val apiKeySecret =
         ApiKeySecret(System.getenv("API_KEY"), System.getenv("API_SECRET"))
 
-    private val clock = Clock.systemUTC()
-
     @BeforeEach
     fun setUp() {
         retrofitApiClientFactory = RetrofitApiClientFactory()

--- a/libs/developers-tx-result-adapter-spring-support/src/main/kotlin/com/linecorp/link/developers/txresult/TxResultAutoConfiguration.kt
+++ b/libs/developers-tx-result-adapter-spring-support/src/main/kotlin/com/linecorp/link/developers/txresult/TxResultAutoConfiguration.kt
@@ -72,7 +72,7 @@ class TxResultAutoConfiguration {
         type = ["com.linecorp.link.developers.txresult.v1.raw.adapter.DomainTxEventsAdapterV1"]
     )
     @Bean
-    fun txEventsAdapterV1(): TxResultAdapter<RawTransactionResult, Set<TransactionEvent>> {
+    fun txEventsAdapterV1(): TxResultAdapter<RawTransactionResult, List<TransactionEvent>> {
         return DomainTxEventsAdapterV1()
     }
 
@@ -84,7 +84,7 @@ class TxResultAutoConfiguration {
     fun txResultAdapterV1(
         txResultSummaryAdapter: TxResultAdapter<RawTransactionResult, TxResultSummary>,
         txMessageAdapter: TxResultAdapter<RawTransactionResult, Set<TxMessage>>,
-        txEventsAdapter: TxResultAdapter<RawTransactionResult, Set<TransactionEvent>>
+        txEventsAdapter: TxResultAdapter<RawTransactionResult, List<TransactionEvent>>
     ): TxResultAdapter<RawTransactionResult, TxResult> {
         return DomainTxResultAdapterV1(
             txResultSummaryAdapter = txResultSummaryAdapter,

--- a/libs/developers-tx-result-adapter-spring-support/src/test/kotlin/com/linecorp/link/developers/txresult/ChainPropertiesLoadingAndBeansTest.kt
+++ b/libs/developers-tx-result-adapter-spring-support/src/test/kotlin/com/linecorp/link/developers/txresult/ChainPropertiesLoadingAndBeansTest.kt
@@ -44,7 +44,7 @@ class ChainPropertiesLoadingAndBeansTest {
     private lateinit var txSummaryAdapterV1: TxResultAdapter<RawTransactionResult, TxResultSummary>
 
     @Autowired
-    private lateinit var txEventsAdapterV1: TxResultAdapter<RawTransactionResult, Set<TransactionEvent>>
+    private lateinit var txEventsAdapterV1: TxResultAdapter<RawTransactionResult, List<TransactionEvent>>
 
     @Autowired
     private lateinit var txResultAdapterV1: TxResultAdapter<RawTransactionResult, TxResult>

--- a/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/txresult/core/model/models.kt
+++ b/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/txresult/core/model/models.kt
@@ -23,7 +23,7 @@ import org.apache.commons.lang3.StringUtils
 data class TxResult(
     val summary: TxResultSummary,
     val messages: Set<TxMessage>,
-    val events: Set<TransactionEvent>,
+    val events: List<TransactionEvent>,
 )
 
 data class TxResultSummary(

--- a/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxEventsAdapterV1.kt
+++ b/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxEventsAdapterV1.kt
@@ -28,16 +28,16 @@ import com.linecorp.link.developers.txresult.v1.raw.model.convertToEventType
 import com.linecorp.link.developers.txresult.v1.raw.model.findAttribute
 import com.linecorp.link.developers.txresult.v1.raw.model.findEvent
 
-class DomainTxEventsAdapterV1 : TxResultAdapter<RawTransactionResult, Set<TransactionEvent>> {
+class DomainTxEventsAdapterV1 : TxResultAdapter<RawTransactionResult, List<TransactionEvent>> {
 
     private val txEventConverter: DomainTxEventConverterV1 = DomainTxEventConverterV1()
 
-    override fun adapt(input: RawTransactionResult): Set<TransactionEvent> {
+    override fun adapt(input: RawTransactionResult): List<TransactionEvent> {
 
         val logs = input.logs
 
         return if (input.code != 0 || logs.isNullOrEmpty()) {
-            emptySet()
+            emptyList()
         } else {
             logs.flatMap { log ->
                 val msgIndex = log.msgIndex
@@ -50,7 +50,7 @@ class DomainTxEventsAdapterV1 : TxResultAdapter<RawTransactionResult, Set<Transa
                 } else {
                     resolveTransactionEvent(eventType, event, log)
                 }
-            }.toSet()
+            }
         }
     }
 

--- a/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxResultAdapterV1.kt
+++ b/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxResultAdapterV1.kt
@@ -26,7 +26,7 @@ import com.linecorp.link.developers.txresult.v1.raw.model.RawTransactionResult
 class DomainTxResultAdapterV1(
     private val txResultSummaryAdapter: TxResultAdapter<RawTransactionResult, TxResultSummary>,
     private val txMessageAdapter: TxResultAdapter<RawTransactionResult, Set<TxMessage>>,
-    private val txEventsAdapter: TxResultAdapter<RawTransactionResult, Set<TransactionEvent>>,
+    private val txEventsAdapter: TxResultAdapter<RawTransactionResult, List<TransactionEvent>>,
 ) : TxResultAdapter<RawTransactionResult, TxResult> {
     override fun adapt(input: RawTransactionResult): TxResult {
         return TxResult(
@@ -36,6 +36,3 @@ class DomainTxResultAdapterV1(
         )
     }
 }
-
-
-

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/jackson/TransactionEventDeserializerTest.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/jackson/TransactionEventDeserializerTest.kt
@@ -198,7 +198,7 @@ class TransactionEventDeserializerTest {
         val actual = objectMapper.readValue(inputStream, typeReference)
         assertTrue(actual.events.any { it is EventTokenProxyApproved })
         val eventCoinTransferred = actual.events.filterIsInstance<EventTokenProxyApproved>().first()
-        assertTrue(eventCoinTransferred.proxyAddress?.isNotBlank() ?: false)
+        assertTrue(eventCoinTransferred.proxyAddress.isNotBlank())
     }
 
 }

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxResultAdapterV1Test.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxResultAdapterV1Test.kt
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test
 class DomainTxResultAdapterV1Test {
     private lateinit var txResultSummaryAdapter: TxResultAdapter<RawTransactionResult, TxResultSummary>
     private lateinit var txMessageAdapter: TxResultAdapter<RawTransactionResult, Set<TxMessage>>
-    private lateinit var txEventsAdapter: TxResultAdapter<RawTransactionResult, Set<TransactionEvent>>
+    private lateinit var txEventsAdapter: TxResultAdapter<RawTransactionResult, List<TransactionEvent>>
     private lateinit var underTest: DomainTxResultAdapterV1
     private lateinit var jsonRawTransactionResultAdapter: JsonRawTransactionResultAdapter
 


### PR DESCRIPTION
### What kind of change does this PR introduce?
* [x] bug fix
* [ ] feature
* [ ] docs
* [x] update

### What is the current behavior?
Using `Set` for events

### What is the new behavior?
Replace `Set` with `List` for events, which means there can be duplicated event