### PR TITLE
fix: lbd custom object mapper and webClient

### DIFF
--- a/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/RequestBodyFlattener.kt
+++ b/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/RequestBodyFlattener.kt
@@ -17,8 +17,8 @@
 
 package com.linecorp.link.developers.client.api
 
-import org.apache.commons.lang3.StringUtils
 import java.util.TreeMap
+import org.apache.commons.lang3.StringUtils
 
 interface RequestBodyFlattener {
     fun flatten(body: Map<String, Any?>): String

--- a/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/RequestQueryParameterSorter.kt
+++ b/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/RequestQueryParameterSorter.kt
@@ -17,11 +17,11 @@
 
 package com.linecorp.link.developers.client.api
 
+import java.util.TreeMap
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
-import java.util.TreeMap
 
 interface RequestQueryParameterSorter : QueryParameterSorter, Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {

--- a/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/retrofit/RetrofitApiClientFactory.kt
+++ b/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/retrofit/RetrofitApiClientFactory.kt
@@ -17,10 +17,7 @@
 
 package com.linecorp.link.developers.client.api.retrofit
 
-import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.module.SimpleModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.linecorp.link.developers.client.api.ApiClient
 import com.linecorp.link.developers.client.api.ApiClientFactory
 import com.linecorp.link.developers.client.api.ApiKeySecret
@@ -29,8 +26,6 @@ import com.linecorp.link.developers.client.api.DefaultRequestQueryParameterOrder
 import com.linecorp.link.developers.client.api.RequestHeadersAppender
 import com.linecorp.link.developers.client.api.RequestQueryParameterSorter
 import com.linecorp.link.developers.jackson.JacksonObjectMapperFactory
-import com.linecorp.link.developers.jackson.TransactionEventDeserializer
-import com.linecorp.link.developers.txresult.core.model.TransactionEvent
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit

--- a/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/retrofit/RetrofitApiClientFactory.kt
+++ b/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/retrofit/RetrofitApiClientFactory.kt
@@ -17,7 +17,9 @@
 
 package com.linecorp.link.developers.client.api.retrofit
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.linecorp.link.developers.client.api.ApiClient
 import com.linecorp.link.developers.client.api.ApiClientFactory
@@ -26,6 +28,9 @@ import com.linecorp.link.developers.client.api.DefaultRequestHeadersAppender
 import com.linecorp.link.developers.client.api.DefaultRequestQueryParameterOrderer
 import com.linecorp.link.developers.client.api.RequestHeadersAppender
 import com.linecorp.link.developers.client.api.RequestQueryParameterSorter
+import com.linecorp.link.developers.jackson.JacksonObjectMapperFactory
+import com.linecorp.link.developers.jackson.TransactionEventDeserializer
+import com.linecorp.link.developers.txresult.core.model.TransactionEvent
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -57,14 +62,14 @@ class RetrofitApiClientFactory : ApiClientFactory {
                 DefaultRequestQueryParameterOrderer.createDefaultInstance(),
                 enableLogging
             )
-        val retrofit = retrofit(baseUrl, okHttp3Client, jacksonObjectMapper())
+        val retrofit = retrofit(baseUrl, okHttp3Client, createObjectMapper())
         return retrofit.create(ApiClient::class.java)
     }
 
     private fun retrofit(
         baseUrl: String,
         okHttp3Client: OkHttpClient,
-        jacksonObjectMapper: ObjectMapper = jacksonObjectMapper(),
+        jacksonObjectMapper: ObjectMapper = createObjectMapper(),
     ): Retrofit {
         return Retrofit.Builder()
             .baseUrl(baseUrl)
@@ -89,5 +94,9 @@ class RetrofitApiClientFactory : ApiClientFactory {
             .addInterceptor(requestHeadersAppender)
             .addInterceptor(requestQueryParameterSorter)
             .addInterceptor(loggingInterceptor).build()
+    }
+
+    private fun createObjectMapper(): ObjectMapper {
+        return JacksonObjectMapperFactory().create()
     }
 }

--- a/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/retrofit/retrofit2-adapters.kt
+++ b/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/retrofit/retrofit2-adapters.kt
@@ -20,6 +20,7 @@ package com.linecorp.link.developers.client.api.retrofit
 import com.linecorp.link.developers.client.response.GenericResponse
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
+import mu.KotlinLogging
 import okhttp3.Request
 import okhttp3.ResponseBody
 import okio.Timeout
@@ -29,6 +30,8 @@ import retrofit2.Callback
 import retrofit2.Converter
 import retrofit2.Response
 import retrofit2.Retrofit
+
+private val logger = KotlinLogging.logger {}
 
 @Suppress("TooManyFunctions")
 internal class NetworkResponseCall<R : Any>(
@@ -62,13 +65,14 @@ internal class NetworkResponseCall<R : Any>(
             }
 
             override fun onFailure(call: Call<R>, throwable: Throwable) {
-                val response: Response<R> = resoleFailure(throwable)
+                val response: Response<R> = resolveFailure(throwable)
                 callback.onResponse(this@NetworkResponseCall, response)
             }
         })
     }
 
-    private fun resoleFailure(throwable: Throwable): Response<R> {
+    private fun resolveFailure(throwable: Throwable): Response<R> {
+        logger.error(throwable) { "Fail to handle response: cause: ${throwable.message}" }
         val response = GenericResponse.unknownResponse(throwable)
         @Suppress("UNCHECKED_CAST")
         return Response.success(response as R)

--- a/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/request/requests.kt
+++ b/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/request/requests.kt
@@ -19,7 +19,6 @@ package com.linecorp.link.developers.client.request
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.linecorp.link.developers.client.util.TokenUtil
-import java.math.BigInteger
 
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientBasicTest.kt
+++ b/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientBasicTest.kt
@@ -18,7 +18,6 @@
 package com.linecorp.link.developers.client.api.retrofit
 
 import com.linecorp.link.developers.client.api.ApiKeySecret
-import java.time.Clock
 import java.time.Instant
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking

--- a/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientGetTxResultOnLocalTest.kt
+++ b/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientGetTxResultOnLocalTest.kt
@@ -1,0 +1,91 @@
+/*
+ *   Copyright 2023 LINE Corporation
+ *
+ *   LINE Corporation licenses this file to you under the Apache License,
+ *   version 2.0 (the "License"); you may not use this file except in compliance
+ *   with the License. You may obtain a copy of the License at:
+ *
+ *     https:www.apache.orglicensesLICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *   License for the specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+
+package com.linecorp.link.developers.client.api.retrofit
+
+import com.linecorp.link.developers.client.api.ApiKeySecret
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ApiClientGetTxResultOnLocalTest {
+    private lateinit var mockWebServer: MockWebServer
+    private val mockServerPort = 3000
+    private lateinit var retrofitApiClientFactory: RetrofitApiClientFactory
+
+    private val baseUrl = "http://localhost:$mockServerPort"
+    private val apiKeySecret = ApiKeySecret("test", "test")
+
+    @BeforeAll
+    fun setUpAll() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start(mockServerPort)
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        mockWebServer.shutdown()
+    }
+
+    @BeforeEach
+    fun setUp() {
+        retrofitApiClientFactory = RetrofitApiClientFactory()
+    }
+
+    @Test
+    fun test_get_lbd_service_details() {
+        val inputStream = this::class.java.classLoader.getResourceAsStream("txresults/burn-ft-txresult-response.json")
+        val body = inputStream.bufferedReader().use { it.readText() }
+        mockWebServer.enqueue(okResponse(body))
+
+        val apiClient = retrofitApiClientFactory.buildDefaultApiClient(
+            baseUrl = baseUrl,
+            enableLogging = true,
+            apiKeySecret = apiKeySecret
+        )
+        val genericResponse = runBlocking {
+            apiClient.transactionV2(
+                txHash = "BC66DB40C56E0EC9921B70146AA2BA377236DA81826320A9A50EA54A846F16AE"
+            )
+        }
+
+        assertNotNull((genericResponse))
+        assertEquals(1000, genericResponse.statusCode)
+        assertEquals("Success", genericResponse.statusMessage)
+        assertNotNull(genericResponse.responseData)
+        assertTrue(genericResponse.responseData?.events?.any { it.eventName == "EventCollectionFtBurned" } ?: false)
+    }
+
+    private fun okResponse(body: String): MockResponse {
+        return MockResponse()
+            .setResponseCode(200)
+            .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .setBody(body)
+
+    }
+}

--- a/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientGetTxResultTest.kt
+++ b/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientGetTxResultTest.kt
@@ -18,8 +18,6 @@
 package com.linecorp.link.developers.client.api.retrofit
 
 import com.linecorp.link.developers.client.api.ApiKeySecret
-import com.linecorp.link.developers.client.request.UserBaseCoinTransferRequest
-import java.time.Clock
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull

--- a/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientIssueServiceTokenTest.kt
+++ b/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientIssueServiceTokenTest.kt
@@ -19,8 +19,6 @@ package com.linecorp.link.developers.client.api.retrofit
 
 import com.linecorp.link.developers.client.api.ApiKeySecret
 import com.linecorp.link.developers.client.request.IssueServiceTokenRequest
-import com.linecorp.link.developers.client.request.UserBaseCoinTransferRequest
-import java.time.Clock
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull

--- a/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientServiceDetailsTest.kt
+++ b/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientServiceDetailsTest.kt
@@ -18,8 +18,6 @@
 package com.linecorp.link.developers.client.api.retrofit
 
 import com.linecorp.link.developers.client.api.ApiKeySecret
-import com.linecorp.link.developers.client.request.UserBaseCoinTransferRequest
-import java.time.Clock
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull

--- a/libs/developers-api-client/src/test/resources/txresults/burn-ft-txresult-response.json
+++ b/libs/developers-api-client/src/test/resources/txresults/burn-ft-txresult-response.json
@@ -1,0 +1,52 @@
+{
+  "responseTime": 1585467717505,
+  "statusCode": 1000,
+  "statusMessage": "Success",
+  "responseData": {
+    "summary": {
+      "height": 1207317,
+      "txHash": "2C981A65B9A2F4DF6EC8CC5E084905A9C2C8488F7E533C9F71394F254D76F039",
+      "txIndex": 0,
+      "timestamp": 1618370726000,
+      "signers": [
+        {
+          "address": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq"
+        }
+      ],
+      "result": {
+        "code": 0,
+        "codeSpace": "",
+        "status": "SUCCEEDED"
+      }
+    },
+    "messages": [
+      {
+        "msgIndex": 0,
+        "requestType": "collection/MsgBurnFT",
+        "details": {
+          "from": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+          "contractId": "61e14383",
+          "amount": [
+            {
+              "tokenId": "0000000100000000",
+              "amount": 1
+            }
+          ]
+        }
+      }
+    ],
+    "events": [
+      {
+        "eventName": "EventCollectionFtBurned",
+        "msgIndex": 0,
+        "contractId": "61e14383",
+        "tokenId": "0000000100000000",
+        "amount": "1",
+        "fromAddress": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+        "proxyAddress": "",
+        "tokenType": "00000001"
+      }
+    ]
+  }
+
+}

--- a/libs/developers-tx-result-adapter-spring-support/README.md
+++ b/libs/developers-tx-result-adapter-spring-support/README.md
@@ -1,0 +1,36 @@
+# LINE Blockchain Developers SDK for Kotlin Spring support
+
+## ChainProperties
+
+Depending on which chain(test-net, main-net) is being used for your dApp application, some configuration is required
+like below.
+
+```yaml
+line:
+  lbd:
+    config:
+      chain:
+        is-main-net: false
+        bech32-hrp: tlink
+```
+
+Above configuration is for test-net, and if the dApp needs main-net, then below one is working.
+
+```yaml
+line:
+  lbd:
+    config:
+      chain:
+        is-main-net: true
+        bech32-hrp: link
+```
+
+The configured properties are required to handle transaction result response. 
+For example `DomainTxSummaryAdapterV1`will be used to adapt [legacy transaction result](https://docs-blockchain.line.biz/api-guide/category-transactions#v1-transactions-txHash-get) into [new transaction result](https://docs-blockchain.line.biz/api-guide/category-transactions#v2-transactions-txHash-get).
+
+## Auto-Configurations
+There are automatically generated beans such as `lbdWebClient`, `jacksonObjectMapperBuilder` and transaction result adapters.
+* lbdWebClient: This is `WebClient`, so can be used to call [APIs](https://docs-blockchain.line.biz/api-guide/API-Reference), if you will use spring-framework and `WebClient`.
+* jacksonObjectMapperBuilder: This is required to handle transaction result in a response. More specifically, you can see there is `events` and its type is `TransactionEvent`, which is super type of each concrete event. Because of that, custom deserializer is required and the `jacksonObjectMapperBuilder` is dealing with it.
+* transaction result adapters: if you see `TxResultAutoConfiguration`, then you can figure out there are default beans for adapters.
+

--- a/libs/developers-tx-result-adapter-spring-support/build.gradle.kts
+++ b/libs/developers-tx-result-adapter-spring-support/build.gradle.kts
@@ -48,6 +48,8 @@ dependencies {
     // https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
     implementation("org.apache.commons:commons-lang3:3.12.0")
 
+    implementation("org.springframework:spring-webflux:5.3.24")
+
     // spring
     implementation("org.yaml:snakeyaml:1.33")
     implementation("org.springframework.boot:spring-boot-starter") {
@@ -62,7 +64,7 @@ dependencies {
     testImplementation("io.mockk:mockk:1.12.4")
     testImplementation("com.squareup.okhttp3:okhttp:4.10.0")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
-    testImplementation("org.springframework:spring-webflux:5.3.24")
+
     testImplementation("org.springframework.boot:spring-boot-starter-reactor-netty:2.7.7")
 }
 

--- a/libs/developers-tx-result-adapter-spring-support/src/main/kotlin/com/linecorp/link/developers/client/WebClientConfiguration.kt
+++ b/libs/developers-tx-result-adapter-spring-support/src/main/kotlin/com/linecorp/link/developers/client/WebClientConfiguration.kt
@@ -1,0 +1,59 @@
+/*
+ *   Copyright 2023 LINE Corporation
+ *
+ *   LINE Corporation licenses this file to you under the Apache License,
+ *   version 2.0 (the "License"); you may not use this file except in compliance
+ *   with the License. You may obtain a copy of the License at:
+ *
+ *     https:www.apache.orglicensesLICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *   License for the specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+
+package com.linecorp.link.developers.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.linecorp.link.developers.jackson.JacksonObjectMapperFactory
+import com.linecorp.link.developers.txresult.v1.raw.adapter.JsonRawTransactionResultAdapter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.http.MediaType
+import org.springframework.http.codec.ClientCodecConfigurer
+import org.springframework.http.codec.json.Jackson2JsonDecoder
+import org.springframework.http.codec.json.Jackson2JsonEncoder
+import org.springframework.web.reactive.function.client.ExchangeStrategies
+import org.springframework.web.reactive.function.client.WebClient
+
+@Configuration
+class WebClientConfiguration {
+
+    @Primary
+    @Bean
+    fun lbdWebClient(objectMapper: ObjectMapper): WebClient {
+        val strategies = buildWebClientStrategies(objectMapper)
+        return WebClient.builder().exchangeStrategies(strategies).build()
+    }
+
+    @Primary
+    @Bean
+    fun objectMapper(): ObjectMapper {
+        return JacksonObjectMapperFactory().create()
+    }
+
+    private fun buildWebClientStrategies(objectMapper: ObjectMapper): ExchangeStrategies {
+        return ExchangeStrategies
+            .builder()
+            .codecs { clientDefaultCodecsConfigurer: ClientCodecConfigurer ->
+                clientDefaultCodecsConfigurer.defaultCodecs()
+                    .jackson2JsonEncoder(Jackson2JsonEncoder(objectMapper, MediaType.APPLICATION_JSON))
+                clientDefaultCodecsConfigurer.defaultCodecs()
+                    .jackson2JsonDecoder(Jackson2JsonDecoder(objectMapper, MediaType.APPLICATION_JSON))
+            }.build()
+    }
+}

--- a/libs/developers-tx-result-adapter-spring-support/src/main/kotlin/com/linecorp/link/developers/client/WebClientConfiguration.kt
+++ b/libs/developers-tx-result-adapter-spring-support/src/main/kotlin/com/linecorp/link/developers/client/WebClientConfiguration.kt
@@ -19,7 +19,6 @@ package com.linecorp.link.developers.client
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.linecorp.link.developers.jackson.JacksonObjectMapperFactory
-import com.linecorp.link.developers.txresult.v1.raw.adapter.JsonRawTransactionResultAdapter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary

--- a/libs/developers-tx-result-adapter-spring-support/src/main/kotlin/com/linecorp/link/developers/txresult/ChainProperties.kt
+++ b/libs/developers-tx-result-adapter-spring-support/src/main/kotlin/com/linecorp/link/developers/txresult/ChainProperties.kt
@@ -25,7 +25,6 @@ import org.springframework.boot.context.properties.ConstructorBinding
 data class ChainProperties(
     val isMainNet: Boolean,
     val bech32Hrp: String,
-    val baseCoinDenomination: String
 ) {
     companion object {
         const val DEFAULT_HRP_PREFIX = "tlink"

--- a/libs/developers-tx-result-adapter-spring-support/src/main/resources/META-INF/spring.factories
+++ b/libs/developers-tx-result-adapter-spring-support/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
- com.linecorp.link.developers.txresult.TxResultAutoConfiguration
+ com.linecorp.link.developers.txresult.TxResultAutoConfiguration, \
+ com.linecorp.link.developers.client.WebClientConfiguration

--- a/libs/developers-tx-result-adapter-spring-support/src/test/kotlin/com/linecorp/link/developers/txresult/ChainPropertiesLoadingAndBeansTest.kt
+++ b/libs/developers-tx-result-adapter-spring-support/src/test/kotlin/com/linecorp/link/developers/txresult/ChainPropertiesLoadingAndBeansTest.kt
@@ -54,7 +54,6 @@ class ChainPropertiesLoadingAndBeansTest {
     fun check_loaded_chainProperties_and_beans() {
         assertNotNull(chainProperties)
         assertEquals("tlink", chainProperties.bech32Hrp)
-        assertEquals("tcony", chainProperties.baseCoinDenomination)
         assertFalse(chainProperties.isMainNet)
 
         // check beans

--- a/libs/developers-tx-result-adapter-spring-support/src/test/kotlin/com/linecorp/link/developers/txresult/SampleControllerTest.kt
+++ b/libs/developers-tx-result-adapter-spring-support/src/test/kotlin/com/linecorp/link/developers/txresult/SampleControllerTest.kt
@@ -1,0 +1,72 @@
+/*
+ *   Copyright 2023 LINE Corporation
+ *
+ *   LINE Corporation licenses this file to you under the Apache License,
+ *   version 2.0 (the "License"); you may not use this file except in compliance
+ *   with the License. You may obtain a copy of the License at:
+ *
+ *     https:www.apache.orglicensesLICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *   License for the specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+
+package com.linecorp.link.developers.txresult
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.linecorp.link.developers.txresult.core.model.TxResult
+import kotlin.test.assertNotNull
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@SpringBootTest(
+    classes = [TestDummyApp::class],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@AutoConfigureWebTestClient
+class SampleControllerTest {
+    @Autowired
+    private lateinit var testWebClient: WebTestClient
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Test
+    fun testApi() {
+        testWebClient.get().uri("/test")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody(String::class.java)
+    }
+
+    @Test
+    fun sampleTxResultJsonString() {
+        testWebClient.get().uri("/sample-tx-result/json-string")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .consumeWith {
+                val txResult = objectMapper.readValue(it.responseBody, TxResult::class.java)
+                assertNotNull(txResult)
+            }
+    }
+
+    @Test
+    fun sampleTxResult() {
+        testWebClient.get().uri("/sample-tx-result")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .consumeWith {
+                val txResult = objectMapper.readValue(it.responseBody, TxResult::class.java)
+                assertNotNull(txResult)
+            }
+    }
+}

--- a/libs/developers-tx-result-adapter-spring-support/src/test/kotlin/com/linecorp/link/developers/txresult/TestDummyApp.kt
+++ b/libs/developers-tx-result-adapter-spring-support/src/test/kotlin/com/linecorp/link/developers/txresult/TestDummyApp.kt
@@ -17,9 +17,14 @@
 
 package com.linecorp.link.developers.txresult
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.linecorp.link.developers.txresult.core.model.TxResult
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.core.io.ClassPathResource
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
 
 @Suppress("EmptyClassBlock")
 @SpringBootApplication()
@@ -32,3 +37,33 @@ class TestDummyApp {
 fun main(args: Array<String>) {
     runApplication<TestDummyApp>(*args)
 }
+
+
+@RestController
+class SampleController(
+    private val objectMapper: ObjectMapper
+) {
+    @GetMapping("/test")
+    fun test(): String {
+        return objectMapper.writeValueAsString(TestData(name = "test"))
+    }
+
+    @GetMapping("/sample-tx-result/json-string")
+    fun sampleTxResultJsonString(): String {
+        val txJsonString = ClassPathResource("./txresults/burn-ft-txresult-response.json").inputStream.bufferedReader()
+            .use { it.readText() }
+        val txResult = objectMapper.readValue(txJsonString, TxResult::class.java)
+        return objectMapper.writeValueAsString(txResult)
+    }
+
+    @GetMapping("/sample-tx-result")
+    fun sampleTxResult(): TxResult {
+        val txJsonString = ClassPathResource("./txresults/burn-ft-txresult-response.json").inputStream.bufferedReader()
+            .use { it.readText() }
+        return objectMapper.readValue(txJsonString, TxResult::class.java)
+    }
+}
+
+data class TestData(
+    val name: String
+)

--- a/libs/developers-tx-result-adapter-spring-support/src/test/resources/config/application.yml
+++ b/libs/developers-tx-result-adapter-spring-support/src/test/resources/config/application.yml
@@ -4,4 +4,3 @@ line:
       chain:
         is-main-net: false
         bech32-hrp: tlink
-        base-coin-denomination: tcony

--- a/libs/developers-tx-result-adapter-spring-support/src/test/resources/txresults/burn-ft-txresult-response.json
+++ b/libs/developers-tx-result-adapter-spring-support/src/test/resources/txresults/burn-ft-txresult-response.json
@@ -1,0 +1,46 @@
+{
+  "summary": {
+    "height": 1207317,
+    "txHash": "2C981A65B9A2F4DF6EC8CC5E084905A9C2C8488F7E533C9F71394F254D76F039",
+    "txIndex": 0,
+    "timestamp": 1618370726000,
+    "signers": [
+      {
+        "address": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq"
+      }
+    ],
+    "result": {
+      "code": 0,
+      "codeSpace": "",
+      "status": "SUCCEEDED"
+    }
+  },
+  "messages": [
+    {
+      "msgIndex": 0,
+      "requestType": "collection/MsgBurnFT",
+      "details": {
+        "from": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+        "contractId": "61e14383",
+        "amount": [
+          {
+            "tokenId": "0000000100000000",
+            "amount": 1
+          }
+        ]
+      }
+    }
+  ],
+  "events": [
+    {
+      "eventName": "EventCollectionFtBurned",
+      "msgIndex": 0,
+      "contractId": "61e14383",
+      "tokenId": "0000000100000000",
+      "amount": "1",
+      "fromAddress": "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+      "proxyAddress": "",
+      "tokenType": "00000001"
+    }
+  ]
+}

--- a/libs/developers-tx-result-adapter/build.gradle.kts
+++ b/libs/developers-tx-result-adapter/build.gradle.kts
@@ -51,6 +51,9 @@ dependencies {
     testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
     testImplementation("org.springframework:spring-webflux:5.3.24")
     testImplementation("org.springframework.boot:spring-boot-starter-reactor-netty:2.7.7")
+
+    testImplementation("com.squareup.okhttp3:okhttp")
+    testImplementation("com.squareup.okhttp3:mockwebserver")
 }
 
 tasks {

--- a/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/chain/crypto/Amino.kt
+++ b/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/chain/crypto/Amino.kt
@@ -17,9 +17,9 @@
 package com.linecorp.link.developers.chain.crypto
 
 import com.google.common.primitives.Bytes
+import java.util.Arrays
 import org.bitcoinj.core.VarInt
 import org.bouncycastle.jcajce.provider.digest.SHA256.Digest
-import java.util.Arrays
 
 internal object Amino {
     private const val DISAMBIGUATION_BYTE_LENGTH = 3

--- a/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/jackson/JacksonObjectMapperFactory.kt
+++ b/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/jackson/JacksonObjectMapperFactory.kt
@@ -34,6 +34,4 @@ class JacksonObjectMapperFactory {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
         return objectMapper
     }
-
-
 }

--- a/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/jackson/JacksonObjectMapperFactory.kt
+++ b/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/jackson/JacksonObjectMapperFactory.kt
@@ -1,0 +1,39 @@
+/*
+ *   Copyright 2023 LINE Corporation
+ *
+ *   LINE Corporation licenses this file to you under the Apache License,
+ *   version 2.0 (the "License"); you may not use this file except in compliance
+ *   with the License. You may obtain a copy of the License at:
+ *
+ *     https:www.apache.orglicensesLICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *   License for the specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+
+package com.linecorp.link.developers.jackson
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.linecorp.link.developers.txresult.core.model.TransactionEvent
+
+class JacksonObjectMapperFactory {
+    fun create(): ObjectMapper {
+        val objectMapper = jacksonObjectMapper()
+        val simpleModule = SimpleModule().addDeserializer(
+            TransactionEvent::class.java,
+            TransactionEventDeserializer()
+        )
+        objectMapper.registerModule(simpleModule)
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        return objectMapper
+    }
+
+
+}

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxEventsAdapterV1Test.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxEventsAdapterV1Test.kt
@@ -18,10 +18,10 @@ package com.linecorp.link.developers.txresult.v1.raw.adapter
 
 import com.linecorp.link.developers.txresult.core.event.item.EventCollectionFtMinted
 import com.linecorp.link.developers.txresult.util.RawTransactionLoader
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class DomainTxEventsAdapterV1Test {
     private lateinit var underTest: DomainTxEventsAdapterV1

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxSummaryAdapterV1Test.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxSummaryAdapterV1Test.kt
@@ -17,11 +17,11 @@
 package com.linecorp.link.developers.txresult.v1.raw.adapter
 
 import com.linecorp.link.developers.txresult.util.RawTransactionLoader
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class DomainTxSummaryAdapterV1Test {
     private lateinit var underTest: DomainTxSummaryAdapterV1

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/JsonRawTransactionResultAdapterTest.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/JsonRawTransactionResultAdapterTest.kt
@@ -17,11 +17,11 @@
 package com.linecorp.link.developers.txresult.v1.raw.adapter
 
 import com.linecorp.link.developers.txresult.helper.RawTransactionLoader
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import kotlin.test.assertTrue
 
 class JsonRawTransactionResultAdapterTest {
     private lateinit var underTest: JsonRawTransactionResultAdapter

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/OpenApiRawTransactionParserTest.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/OpenApiRawTransactionParserTest.kt
@@ -20,6 +20,11 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.linecorp.link.developers.GenericResponse
 import com.linecorp.link.developers.txresult.v1.raw.model.RawTransactionResult
+import java.nio.file.Files
+import java.util.stream.Collectors
+import kotlin.io.path.toPath
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterAll
@@ -30,11 +35,6 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
-import java.nio.file.Files
-import java.util.stream.Collectors
-import kotlin.io.path.toPath
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OpenApiRawTransactionParserTest {

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventAdapterV1FailedCasesTest.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventAdapterV1FailedCasesTest.kt
@@ -19,10 +19,10 @@ package com.linecorp.link.developers.txresult.v1.raw.adapter.event
 import com.linecorp.link.developers.txresult.util.RawTransactionLoader
 import com.linecorp.link.developers.txresult.v1.raw.adapter.DomainTxEventsAdapterV1
 import com.linecorp.link.developers.txresult.v1.raw.adapter.JsonRawTransactionResultAdapter
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class DomainTxEventAdapterV1FailedCasesTest {
     private lateinit var underTest: DomainTxEventsAdapterV1

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1AccountsTest.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1AccountsTest.kt
@@ -21,10 +21,10 @@ import com.linecorp.link.developers.txresult.core.event.account.EventEmptyMsgCre
 import com.linecorp.link.developers.txresult.util.RawTransactionLoader
 import com.linecorp.link.developers.txresult.v1.raw.adapter.DomainTxEventsAdapterV1
 import com.linecorp.link.developers.txresult.v1.raw.adapter.JsonRawTransactionResultAdapter
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class DomainTxEventsAdapterV1AccountsTest {
     private lateinit var underTest: DomainTxEventsAdapterV1

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1CoinTest.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1CoinTest.kt
@@ -20,10 +20,10 @@ import com.linecorp.link.developers.txresult.core.event.bank.EventCoinTransferre
 import com.linecorp.link.developers.txresult.util.RawTransactionLoader
 import com.linecorp.link.developers.txresult.v1.raw.adapter.DomainTxEventsAdapterV1
 import com.linecorp.link.developers.txresult.v1.raw.adapter.JsonRawTransactionResultAdapter
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class DomainTxEventsAdapterV1CoinTest {
     private lateinit var underTest: DomainTxEventsAdapterV1

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1CollectionAttachTest.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1CollectionAttachTest.kt
@@ -21,10 +21,10 @@ import com.linecorp.link.developers.txresult.core.event.item.EventCollectionNftR
 import com.linecorp.link.developers.txresult.util.RawTransactionLoader
 import com.linecorp.link.developers.txresult.v1.raw.adapter.DomainTxEventsAdapterV1
 import com.linecorp.link.developers.txresult.v1.raw.adapter.JsonRawTransactionResultAdapter
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class DomainTxEventsAdapterV1CollectionAttachTest {
     private lateinit var underTest: DomainTxEventsAdapterV1

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1CollectionBurnTest.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1CollectionBurnTest.kt
@@ -21,10 +21,10 @@ import com.linecorp.link.developers.txresult.core.event.item.EventCollectionNftB
 import com.linecorp.link.developers.txresult.util.RawTransactionLoader
 import com.linecorp.link.developers.txresult.v1.raw.adapter.DomainTxEventsAdapterV1
 import com.linecorp.link.developers.txresult.v1.raw.adapter.JsonRawTransactionResultAdapter
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class DomainTxEventsAdapterV1CollectionBurnTest {
 

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1CollectionDetachTest.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1CollectionDetachTest.kt
@@ -21,10 +21,10 @@ import com.linecorp.link.developers.txresult.core.event.item.EventCollectionNftR
 import com.linecorp.link.developers.txresult.util.RawTransactionLoader
 import com.linecorp.link.developers.txresult.v1.raw.adapter.DomainTxEventsAdapterV1
 import com.linecorp.link.developers.txresult.v1.raw.adapter.JsonRawTransactionResultAdapter
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class DomainTxEventsAdapterV1CollectionDetachTest {
     private lateinit var underTest: DomainTxEventsAdapterV1

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1CollectionIssueTest.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1CollectionIssueTest.kt
@@ -21,10 +21,10 @@ import com.linecorp.link.developers.txresult.core.event.item.EventCollectionNftI
 import com.linecorp.link.developers.txresult.util.RawTransactionLoader
 import com.linecorp.link.developers.txresult.v1.raw.adapter.DomainTxEventsAdapterV1
 import com.linecorp.link.developers.txresult.v1.raw.adapter.JsonRawTransactionResultAdapter
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class DomainTxEventsAdapterV1CollectionIssueTest {
 

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1CollectionMintTest.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1CollectionMintTest.kt
@@ -21,10 +21,10 @@ import com.linecorp.link.developers.txresult.core.event.item.EventCollectionNftM
 import com.linecorp.link.developers.txresult.util.RawTransactionLoader
 import com.linecorp.link.developers.txresult.v1.raw.adapter.DomainTxEventsAdapterV1
 import com.linecorp.link.developers.txresult.v1.raw.adapter.JsonRawTransactionResultAdapter
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class DomainTxEventsAdapterV1CollectionMintTest {
 

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1CollectionTest.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1CollectionTest.kt
@@ -22,10 +22,10 @@ import com.linecorp.link.developers.txresult.core.event.item.EventCollectionProx
 import com.linecorp.link.developers.txresult.util.RawTransactionLoader
 import com.linecorp.link.developers.txresult.v1.raw.adapter.DomainTxEventsAdapterV1
 import com.linecorp.link.developers.txresult.v1.raw.adapter.JsonRawTransactionResultAdapter
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class DomainTxEventsAdapterV1CollectionTest {
     private lateinit var underTest: DomainTxEventsAdapterV1

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1CollectionTransferTest.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1CollectionTransferTest.kt
@@ -22,10 +22,10 @@ import com.linecorp.link.developers.txresult.core.event.item.EventCollectionNftT
 import com.linecorp.link.developers.txresult.util.RawTransactionLoader
 import com.linecorp.link.developers.txresult.v1.raw.adapter.DomainTxEventsAdapterV1
 import com.linecorp.link.developers.txresult.v1.raw.adapter.JsonRawTransactionResultAdapter
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class DomainTxEventsAdapterV1CollectionTransferTest {
 

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1TokenTest.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/event/DomainTxEventsAdapterV1TokenTest.kt
@@ -25,10 +25,10 @@ import com.linecorp.link.developers.txresult.core.event.token.EventTokenTransfer
 import com.linecorp.link.developers.txresult.util.RawTransactionLoader
 import com.linecorp.link.developers.txresult.v1.raw.adapter.DomainTxEventsAdapterV1
 import com.linecorp.link.developers.txresult.v1.raw.adapter.JsonRawTransactionResultAdapter
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class DomainTxEventsAdapterV1TokenTest {
     private lateinit var underTest: DomainTxEventsAdapterV1

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v2/GetNewTxResultTest.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v2/GetNewTxResultTest.kt
@@ -1,0 +1,102 @@
+/*
+ *   Copyright 2023 LINE Corporation
+ *
+ *   LINE Corporation licenses this file to you under the Apache License,
+ *   version 2.0 (the "License"); you may not use this file except in compliance
+ *   with the License. You may obtain a copy of the License at:
+ *
+ *     https:www.apache.orglicensesLICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *   License for the specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+
+package com.linecorp.link.developers.txresult.v2
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.linecorp.link.developers.jackson.TransactionEventDeserializer
+import com.linecorp.link.developers.txresult.core.model.TransactionEvent
+import com.linecorp.link.developers.txresult.core.model.TxResult
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.codec.ClientCodecConfigurer
+import org.springframework.http.codec.json.Jackson2JsonDecoder
+import org.springframework.http.codec.json.Jackson2JsonEncoder
+import org.springframework.web.reactive.function.client.ExchangeStrategies
+import org.springframework.web.reactive.function.client.WebClient
+
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GetNewTxResultTest {
+    private lateinit var mockWebServer: MockWebServer
+    private val mockServerPort = 3000
+
+    private val objectMapper = createObjectMapper()
+    private val strategies = ExchangeStrategies
+        .builder()
+        .codecs { clientDefaultCodecsConfigurer: ClientCodecConfigurer ->
+            clientDefaultCodecsConfigurer.defaultCodecs()
+                .jackson2JsonEncoder(Jackson2JsonEncoder(objectMapper, MediaType.APPLICATION_JSON))
+            clientDefaultCodecsConfigurer.defaultCodecs()
+                .jackson2JsonDecoder(Jackson2JsonDecoder(objectMapper, MediaType.APPLICATION_JSON))
+        }.build()
+
+    private val webClient =
+        WebClient.builder().exchangeStrategies(strategies).baseUrl("http://localhost:$mockServerPort").build()
+
+    private fun createObjectMapper(): ObjectMapper {
+        val objectMapper = jacksonObjectMapper()
+        val simpleModule = SimpleModule().addDeserializer(
+            TransactionEvent::class.java,
+            TransactionEventDeserializer()
+        )
+        objectMapper.registerModule(simpleModule)
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        return objectMapper
+    }
+
+    @BeforeAll
+    fun setUpAll() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start(mockServerPort)
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun getNewTxResult() {
+
+        val inputStream = this::class.java.classLoader.getResourceAsStream("./txresults/burn-ft-txresult.json")
+        val body = inputStream.bufferedReader().use { it.readText() }
+        mockWebServer.enqueue(okResponse(body))
+
+        val txResult = webClient.get().retrieve().bodyToMono(TxResult::class.java).block()
+        assertNotNull(txResult)
+        assertTrue(txResult.events.any { it.eventName == "EventCollectionFtBurned" })
+    }
+
+    private fun okResponse(body: String): MockResponse {
+        return MockResponse()
+            .setResponseCode(200)
+            .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .setBody(body)
+    }
+}

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v2/GetNewTxResultTest.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v2/GetNewTxResultTest.kt
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.linecorp.link.developers.jackson.TransactionEventDeserializer
 import com.linecorp.link.developers.txresult.core.model.TransactionEvent
 import com.linecorp.link.developers.txresult.core.model.TxResult
+import com.linecorp.link.developers.util.TestSocketUtils
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import okhttp3.mockwebserver.MockResponse
@@ -44,7 +45,7 @@ import org.springframework.web.reactive.function.client.WebClient
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GetNewTxResultTest {
     private lateinit var mockWebServer: MockWebServer
-    private val mockServerPort = 3000
+    private val mockServerPort = TestSocketUtils.findAvailableTcpPort()
 
     private val objectMapper = createObjectMapper()
     private val strategies = ExchangeStrategies

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/util/TestSocketUtils.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/util/TestSocketUtils.kt
@@ -1,0 +1,103 @@
+/*
+ *   Copyright 2023 LINE Corporation
+ *
+ *   LINE Corporation licenses this file to you under the Apache License,
+ *   version 2.0 (the "License"); you may not use this file except in compliance
+ *   with the License. You may obtain a copy of the License at:
+ *
+ *     https:www.apache.orglicensesLICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *   License for the specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+
+package com.linecorp.link.developers.util
+
+
+import java.net.InetAddress
+import java.util.Random
+import javax.net.ServerSocketFactory
+
+// copy from https://github.com/onobc/spring-framework/blob/f2c2374b588e428575f5db347b7aa5cca19ff3e2/spring-test/src/main/java/org/springframework/test/util/TestSocketUtils.java
+/**
+ * Simple utility methods for finding available ports on `localhost` for
+ * use in integration testing scenarios.
+ *
+ *
+ * This is a limited form of `SocketUtils` which is deprecated in Spring
+ * Framework 5.3 and removed in Spring Framework 6.0.
+ *
+ *
+ * `SocketUtils` was introduced in Spring Framework 4.0, primarily to
+ * assist in writing integration tests which start an external server on an
+ * available random port. However, these utilities make no guarantee about the
+ * subsequent availability of a given port and are therefore unreliable (the reason
+ * for deprecation and removal).
+ *
+ *
+ * Instead of using `TestSocketUtils` to find an available local port for a server,
+ * it is recommended that you rely on a server's ability to start on a random port
+ * that it selects or is assigned by the operating system. To interact with that
+ * server, you should query the server for the port it is currently using.
+ *
+ * @author Sam Brannen
+ * @author Ben Hale
+ * @author Arjen Poutsma
+ * @author Gunnar Hillert
+ * @author Gary Russell
+ * @author Chris Bono
+ * @since 5.3
+ */
+object TestSocketUtils {
+    /**
+     * The minimum value for port ranges used when finding an available TCP port.
+     */
+    private const val PORT_RANGE_MIN = 1024
+
+    /**
+     * The maximum value for port ranges used when finding an available TCP port.
+     */
+    private const val PORT_RANGE_MAX = 65535
+    private const val PORT_RANGE = PORT_RANGE_MAX - PORT_RANGE_MIN
+    private const val MAX_ATTEMPTS = 1000
+    private val random = Random(System.nanoTime())
+
+    /**
+     * Find an available TCP port randomly selected from the range [1024, 65535].
+     * @return an available TCP port number
+     * @throws IllegalStateException if no available port could be found within max attempts
+     */
+    @Suppress("MaxLineLength")
+    fun findAvailableTcpPort(): Int {
+        var candidatePort: Int
+        var searchCounter = 0
+        do {
+            check(searchCounter <= MAX_ATTEMPTS) {
+                "Could not find an available TCP port in the range [$PORT_RANGE_MIN, $PORT_RANGE_MAX] after $MAX_ATTEMPTS attempts"
+            }
+            candidatePort = PORT_RANGE_MIN + random.nextInt(PORT_RANGE + 1)
+            searchCounter++
+        } while (!isPortAvailable(candidatePort))
+        return candidatePort
+    }
+
+    /**
+     * Determine if the specified TCP port is currently available on `localhost`.
+     */
+    @Suppress("SwallowedException")
+    private fun isPortAvailable(port: Int): Boolean {
+        return try {
+            val serverSocket = ServerSocketFactory.getDefault().createServerSocket(
+                port, 1, InetAddress.getByName("localhost")
+            )
+            serverSocket.close()
+            true
+        } catch (ex: Exception) {
+            false
+        }
+    }
+}


### PR DESCRIPTION
### What kind of change does this PR introduce?
* [x] bug fix
* [x] feature
* [ ] docs
* [ ] update

### What is the current behavior?
Fail to resolve new tx-result response because of tx-events

### What is the new behavior?
Fix to correctly resolve new tx-result response
* custom object-mapper
  * Using `TransactionEventDeserializer`
  * Create with `JacksonObjectMapperFactory`
* custom webClient - `lbdWebClient`  
* Fix `RetrofitApiClientFactory` to use custom object-mapper