### PR TITLE
feat: make message details to empty

### DIFF
--- a/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/txresult/core/model/models.kt
+++ b/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/txresult/core/model/models.kt
@@ -50,8 +50,9 @@ data class TxStatusResult(
 data class TxMessage(
     val msgIndex: Int,
     val requestType: String,
-    val details: Any,
-)
+) {
+    val details: Any = emptyMap<String, Any>() // details are always empty.
+}
 
 interface TransactionEvent {
     val eventName: String

--- a/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxMessageAdapterV1.kt
+++ b/libs/developers-tx-result-adapter/src/main/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxMessageAdapterV1.kt
@@ -27,8 +27,7 @@ class DomainTxMessageAdapterV1: TxResultAdapter<RawTransactionResult, Set<TxMess
 
         return rawMessages.mapIndexed { index, rawMessage ->
             val type = rawMessage.type
-            @Suppress("UNCHECKED_CAST") val details = rawMessage.value as Map<String, Any>
-            TxMessage(msgIndex = index, requestType = type, details = details)
+            TxMessage(msgIndex = index, requestType = type)
         }.toSet()
     }
 }

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxMessageAdapterV1Test.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxMessageAdapterV1Test.kt
@@ -63,12 +63,6 @@ class DomainTxMessageAdapterV1Test {
         assertEquals(1, txResultMessages.size)
         assertNotNull(txResultMessages.find { it.requestType == "collection/MsgMintFT" })
         val txResultMessage = txResultMessages.find { it.requestType == "collection/MsgMintFT" }
-        val details = txResultMessage?.details as Map<String, String>
-        assertEquals(details["from"], "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq")
-        assertEquals(details["contractId"], "61e14383")
-        assertEquals(details["to"], "tlink147zxfhrxaxhsqljpz8raqrgnxj7f3wnthdjeky")
-        val amounts = (details["amount"] as List<Map<String, Any>>)
-        assertEquals(amounts[0]["tokenId"], "0000000100000000")
-        assertEquals(amounts[0]["amount"], 1000)
+        assertEquals(0, txResultMessage?.msgIndex)
     }
 }

--- a/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxResultAdapterV1Test.kt
+++ b/libs/developers-tx-result-adapter/src/test/kotlin/com/linecorp/link/developers/txresult/v1/raw/adapter/DomainTxResultAdapterV1Test.kt
@@ -73,13 +73,7 @@ class DomainTxResultAdapterV1Test {
         assertEquals(1, txResult.messages.size)
         assertNotNull(txResult.messages.find { it.requestType == "collection/MsgMintFT" })
         val txResultMessage = txResult.messages.find { it.requestType == "collection/MsgMintFT" }
-        val details = txResultMessage?.details as Map<String, String>
-        assertEquals(details["from"], "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq")
-        assertEquals(details["contractId"], "61e14383")
-        assertEquals(details["to"], "tlink147zxfhrxaxhsqljpz8raqrgnxj7f3wnthdjeky")
-        val amounts = (details["amount"] as List<Map<String, Any>>)
-        assertEquals(amounts[0]["tokenId"], "0000000100000000")
-        assertEquals(amounts[0]["amount"], 1000)
+        assertEquals(0, txResultMessage?.msgIndex)
 
         val mintFtEvent = txResult.events.firstOrNull { it::class == EventCollectionFtMinted::class }
         assertNotNull(mintFtEvent)


### PR DESCRIPTION
### What kind of change does this PR introduce?
* [ ] bug fix
* [x] feature
* [ ] docs
* [ ] update

### What is the current behavior?
Message details no longer give data

### What is the new behavior?
Make message details to empty

### Other information
