### PR TITLE
feat: new v2 api to query nft holders

### DIFF
--- a/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/ApiClient.kt
+++ b/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/ApiClient.kt
@@ -615,7 +615,7 @@ interface ApiClient {
         @Query("limit") limit: Int = 10,
         @Query("pageToken") pageToken: String? = null,
         @Query("orderBy") orderBy: OrderBy = OrderBy.ASC,
-        ): GenericResponse<NonFungibleTokenTypeHolderList>
+    ): GenericResponse<NonFungibleTokenTypeHolderList>
 
     /**
      * Retrieve the holder of a specific non-fungible

--- a/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/ApiClient.kt
+++ b/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/ApiClient.kt
@@ -64,7 +64,6 @@ import com.linecorp.link.developers.client.request.NON_FUNGIBLE_TOKEN_MULTI_RECI
 import com.linecorp.link.developers.client.request.NON_FUNGIBLE_TOKEN_PARENT_PATH
 import com.linecorp.link.developers.client.request.NON_FUNGIBLE_TOKEN_ROOT_PATH
 import com.linecorp.link.developers.client.request.NON_FUNGIBLE_TOKEN_TYPE_HOLDERS_PATH
-import com.linecorp.link.developers.client.request.V2_NON_FUNGIBLE_TOKEN_TYPE_HOLDERS_PATH
 import com.linecorp.link.developers.client.request.NON_FUNGIBLE_TOKEN_TYPE_PATH
 import com.linecorp.link.developers.client.request.NonFungibleTokenBurnRequest
 import com.linecorp.link.developers.client.request.NonFungibleTokenCreateUpdateRequest
@@ -114,6 +113,7 @@ import com.linecorp.link.developers.client.request.V1_USER_TRANSACTIONS_PATH
 import com.linecorp.link.developers.client.request.V1_WALLET_LIST_PATH
 import com.linecorp.link.developers.client.request.V1_WALLET_PATH
 import com.linecorp.link.developers.client.request.V1_WALLET_TRANSACTIONS_PATH
+import com.linecorp.link.developers.client.request.V2_NON_FUNGIBLE_TOKEN_TYPE_HOLDERS_PATH
 import com.linecorp.link.developers.client.request.V2_TRANSACTION_PATH
 import com.linecorp.link.developers.client.request.V2_USER_TRANSACTIONS_PATH
 import com.linecorp.link.developers.client.request.V2_WALLET_TRANSACTIONS_PATH

--- a/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/ApiClient.kt
+++ b/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/ApiClient.kt
@@ -64,6 +64,7 @@ import com.linecorp.link.developers.client.request.NON_FUNGIBLE_TOKEN_MULTI_RECI
 import com.linecorp.link.developers.client.request.NON_FUNGIBLE_TOKEN_PARENT_PATH
 import com.linecorp.link.developers.client.request.NON_FUNGIBLE_TOKEN_ROOT_PATH
 import com.linecorp.link.developers.client.request.NON_FUNGIBLE_TOKEN_TYPE_HOLDERS_PATH
+import com.linecorp.link.developers.client.request.V2_NON_FUNGIBLE_TOKEN_TYPE_HOLDERS_PATH
 import com.linecorp.link.developers.client.request.NON_FUNGIBLE_TOKEN_TYPE_PATH
 import com.linecorp.link.developers.client.request.NonFungibleTokenBurnRequest
 import com.linecorp.link.developers.client.request.NonFungibleTokenCreateUpdateRequest
@@ -140,6 +141,7 @@ import com.linecorp.link.developers.client.response.NonFungibleId
 import com.linecorp.link.developers.client.response.NonFungibleTokenHolder
 import com.linecorp.link.developers.client.response.NonFungibleTokenType
 import com.linecorp.link.developers.client.response.NonFungibleTokenTypeHolder
+import com.linecorp.link.developers.client.response.NonFungibleTokenTypeHolderList
 import com.linecorp.link.developers.client.response.ProxyStatus
 import com.linecorp.link.developers.client.response.RequestSession
 import com.linecorp.link.developers.client.response.RequestSessionStatus
@@ -602,6 +604,18 @@ interface ApiClient {
         @Query("page") page: Int = 1,
         @Query("orderBy") orderBy: OrderBy = OrderBy.ASC,
     ): GenericResponse<Collection<NonFungibleTokenTypeHolder>>
+
+    /**
+     * Retrieve holders of a specific non-fungible token type
+     */
+    @GET(V2_NON_FUNGIBLE_TOKEN_TYPE_HOLDERS_PATH)
+    suspend fun nonFungibleTokenTypeHoldersV2(
+        @Path("contractId") contractId: String,
+        @Path("tokenType") tokenType: String,
+        @Query("limit") limit: Int = 10,
+        @Query("pageToken") pageToken: String? = null,
+        @Query("orderBy") orderBy: OrderBy = OrderBy.ASC,
+        ): GenericResponse<NonFungibleTokenTypeHolderList>
 
     /**
      * Retrieve the holder of a specific non-fungible

--- a/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/request/request-path-list.kt
+++ b/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/request/request-path-list.kt
@@ -98,6 +98,9 @@ const val NON_FUNGIBLE_TOKEN_BURN_PATH =
     "$V1/item-tokens/{contractId}/non-fungibles/{tokenType}/{tokenIndex}/burn"
 const val NON_FUNGIBLE_TOKEN_TYPE_HOLDERS_PATH =
     "$V1/item-tokens/{contractId}/non-fungibles/{tokenType}/holders"
+const val V2_NON_FUNGIBLE_TOKEN_TYPE_HOLDERS_PATH =
+    "$V2/item-tokens/{contractId}/non-fungibles/{tokenType}/holders"
+
 const val NON_FUNGIBLE_TOKEN_HOLDER_PATH =
     "$V1/item-tokens/{contractId}/non-fungibles/{tokenType}/{tokenIndex}/holder"
 const val NON_FUNGIBLE_TOKEN_CHILDREN_PATH =

--- a/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/request/request-path-list.kt
+++ b/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/request/request-path-list.kt
@@ -122,7 +122,6 @@ const val ITEM_TOKEN_FT_THUMBNAIL_REFRESH_STATUS_PATH =
     "$V1/item-tokens/{contractId}/fungibles/thumbnails/{requestId}/status"
 
 
-
 // user api path
 const val V1_USERS = "$V1/users"
 const val V2_USERS = "$V2/users"
@@ -161,9 +160,9 @@ const val USER_NON_FUNGIBLE_TOKEN_TRANSFER_PATH =
 const val USER_NON_FUNGIBLE_TOKEN_BATCH_TRANSFER_PATH =
     "$V1_USERS/{userId}/item-tokens/{contractId}/non-fungibles/batch-transfer"
 
-const val ITEM_TOKEN_FT_MEDIA_RESOURCE_REFRESH_PATH= "$V1/item-tokens/{contractId}/fungibles/media-resources"
-const val ITEM_TOKEN_FT_THUMBNAIL_REFRESH_PATH= "$V1/item-tokens/{contractId}/fungibles/thumbnails"
-const val ITEM_TOKEN_NFT_MEDIA_RESOURCE_REFRESH_PATH= "$V1/item-tokens/{contractId}/non-fungibles/media-resources"
-const val ITEM_TOKEN_NFT_THUMBNAIL_REFRESH_PATH= "$V1/item-tokens/{contractId}/non-fungibles/thumbnails"
+const val ITEM_TOKEN_FT_MEDIA_RESOURCE_REFRESH_PATH = "$V1/item-tokens/{contractId}/fungibles/media-resources"
+const val ITEM_TOKEN_FT_THUMBNAIL_REFRESH_PATH = "$V1/item-tokens/{contractId}/fungibles/thumbnails"
+const val ITEM_TOKEN_NFT_MEDIA_RESOURCE_REFRESH_PATH = "$V1/item-tokens/{contractId}/non-fungibles/media-resources"
+const val ITEM_TOKEN_NFT_THUMBNAIL_REFRESH_PATH = "$V1/item-tokens/{contractId}/non-fungibles/thumbnails"
 
 const val TX_MESSAGES_PATH = "$V2_TRANSACTION_PATH/messages"

--- a/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/response/responses.kt
+++ b/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/response/responses.kt
@@ -277,6 +277,12 @@ data class NonFungibleTokenTypeHolder(
     val numberOfIndex: String,
 )
 
+data class NonFungibleTokenTypeHolderList(
+    val list: List<NonFungibleTokenTypeHolder>,
+    val prePageToken: String? = null,
+    val nextPageToken: String? = null,
+)
+
 data class NonFungibleTokenHolder(
     val tokenId: String,
     val userId: String?,

--- a/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/response/responses.kt
+++ b/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/response/responses.kt
@@ -279,8 +279,8 @@ data class NonFungibleTokenTypeHolder(
 
 data class NonFungibleTokenTypeHolderList(
     val list: List<NonFungibleTokenTypeHolder>,
-    val prePageToken: String? = null,
-    val nextPageToken: String? = null,
+    val prePageToken: String = "",
+    val nextPageToken: String = "",
 )
 
 data class NonFungibleTokenHolder(

--- a/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/ApiListTest.kt
+++ b/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/ApiListTest.kt
@@ -136,6 +136,7 @@ class ApiListTest {
             "GET /v1/item-tokens/{contractId}/non-fungibles/{tokenType}",
             "GET /v1/item-tokens/{contractId}/fungibles/{tokenType}/holders",
             "GET /v1/item-tokens/{contractId}/non-fungibles/{tokenType}/holders",
+            "GET /v2/item-tokens/{contractId}/non-fungibles/{tokenType}/holders",
             "GET /v1/item-tokens/{contractId}",
             "GET /v1/item-tokens/{contractId}/non-fungibles/{tokenType}/{tokenIndex}/children",
             "GET /v1/item-tokens/{contractId}/non-fungibles/{tokenType}/{tokenIndex}/parent",

--- a/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/ApiListTest.kt
+++ b/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/ApiListTest.kt
@@ -59,7 +59,7 @@ class ApiListTest {
             }
         }
 
-        val actualAPIs = ( postAPIs +postAPIs2 ).sorted()
+        val actualAPIs = (postAPIs + postAPIs2).sorted()
 
         val expectedPOSTAPIs = listOfAPIs.filter { it.startsWith("POST") }.sorted()
         assertEquals(expectedPOSTAPIs, actualAPIs)
@@ -85,7 +85,7 @@ class ApiListTest {
             }
         }
 
-        val actualAPIs = ( putAPIs +putAPIs2 ).sorted()
+        val actualAPIs = (putAPIs + putAPIs2).sorted()
 
         val expectedPUTAPIs = listOfAPIs.filter { it.startsWith("PUT") }.sorted()
         assertEquals(expectedPUTAPIs, actualAPIs)
@@ -110,7 +110,7 @@ class ApiListTest {
             }
         }
 
-        val actualAPIs = ( deleteAPIs +deleteAPIs2 ).sorted()
+        val actualAPIs = (deleteAPIs + deleteAPIs2).sorted()
 
         val expectedDELETEAPIs = listOfAPIs.filter { it.startsWith("DELETE") }.sorted()
         assertEquals(expectedDELETEAPIs, actualAPIs)

--- a/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/TestSocketUtils.kt
+++ b/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/TestSocketUtils.kt
@@ -1,0 +1,86 @@
+package com.linecorp.link.developers.client.api
+
+import java.net.InetAddress
+import java.util.Random
+import javax.net.ServerSocketFactory
+
+// copy from https://github.com/onobc/spring-framework/blob/f2c2374b588e428575f5db347b7aa5cca19ff3e2/spring-test/src/main/java/org/springframework/test/util/TestSocketUtils.java
+/**
+ * Simple utility methods for finding available ports on `localhost` for
+ * use in integration testing scenarios.
+ *
+ *
+ * This is a limited form of `SocketUtils` which is deprecated in Spring
+ * Framework 5.3 and removed in Spring Framework 6.0.
+ *
+ *
+ * `SocketUtils` was introduced in Spring Framework 4.0, primarily to
+ * assist in writing integration tests which start an external server on an
+ * available random port. However, these utilities make no guarantee about the
+ * subsequent availability of a given port and are therefore unreliable (the reason
+ * for deprecation and removal).
+ *
+ *
+ * Instead of using `TestSocketUtils` to find an available local port for a server,
+ * it is recommended that you rely on a server's ability to start on a random port
+ * that it selects or is assigned by the operating system. To interact with that
+ * server, you should query the server for the port it is currently using.
+ *
+ * @author Sam Brannen
+ * @author Ben Hale
+ * @author Arjen Poutsma
+ * @author Gunnar Hillert
+ * @author Gary Russell
+ * @author Chris Bono
+ * @since 5.3
+ */
+object TestSocketUtils {
+    /**
+     * The minimum value for port ranges used when finding an available TCP port.
+     */
+    private const val PORT_RANGE_MIN = 1024
+
+    /**
+     * The maximum value for port ranges used when finding an available TCP port.
+     */
+    private const val PORT_RANGE_MAX = 65535
+    private const val PORT_RANGE = PORT_RANGE_MAX - PORT_RANGE_MIN
+    private const val MAX_ATTEMPTS = 1000
+    private val random = Random(System.nanoTime())
+
+    /**
+     * Find an available TCP port randomly selected from the range [1024, 65535].
+     * @return an available TCP port number
+     * @throws IllegalStateException if no available port could be found within max attempts
+     */
+    fun findAvailableTcpPort(): Int {
+        var candidatePort: Int
+        var searchCounter = 0
+        do {
+            check(searchCounter <= MAX_ATTEMPTS) {
+                String.format(
+                    "Could not find an available TCP port in the range [%d, %d] after %d attempts",
+                    PORT_RANGE_MIN, PORT_RANGE_MAX, MAX_ATTEMPTS
+                )
+            }
+            candidatePort = PORT_RANGE_MIN + random.nextInt(PORT_RANGE + 1)
+            searchCounter++
+        } while (!isPortAvailable(candidatePort))
+        return candidatePort
+    }
+
+    /**
+     * Determine if the specified TCP port is currently available on `localhost`.
+     */
+    private fun isPortAvailable(port: Int): Boolean {
+        return try {
+            val serverSocket = ServerSocketFactory.getDefault().createServerSocket(
+                port, 1, InetAddress.getByName("localhost")
+            )
+            serverSocket.close()
+            true
+        } catch (ex: Exception) {
+            false
+        }
+    }
+}

--- a/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/TestSocketUtils.kt
+++ b/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/TestSocketUtils.kt
@@ -53,15 +53,13 @@ object TestSocketUtils {
      * @return an available TCP port number
      * @throws IllegalStateException if no available port could be found within max attempts
      */
+    @Suppress("MaxLineLength")
     fun findAvailableTcpPort(): Int {
         var candidatePort: Int
         var searchCounter = 0
         do {
             check(searchCounter <= MAX_ATTEMPTS) {
-                String.format(
-                    "Could not find an available TCP port in the range [%d, %d] after %d attempts",
-                    PORT_RANGE_MIN, PORT_RANGE_MAX, MAX_ATTEMPTS
-                )
+                "Could not find an available TCP port in the range [$PORT_RANGE_MIN, $PORT_RANGE_MAX] after $MAX_ATTEMPTS attempts"
             }
             candidatePort = PORT_RANGE_MIN + random.nextInt(PORT_RANGE + 1)
             searchCounter++
@@ -72,6 +70,7 @@ object TestSocketUtils {
     /**
      * Determine if the specified TCP port is currently available on `localhost`.
      */
+    @Suppress("SwallowedException")
     private fun isPortAvailable(port: Int): Boolean {
         return try {
             val serverSocket = ServerSocketFactory.getDefault().createServerSocket(

--- a/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientNftHolderV2Test.kt
+++ b/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientNftHolderV2Test.kt
@@ -1,0 +1,118 @@
+/*
+ *   Copyright 2023 LINE Corporation
+ *
+ *   LINE Corporation licenses this file to you under the Apache License,
+ *   version 2.0 (the "License"); you may not use this file except in compliance
+ *   with the License. You may obtain a copy of the License at:
+ *
+ *     https:www.apache.orglicensesLICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *   License for the specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+
+package com.linecorp.link.developers.client.api.retrofit
+import com.linecorp.link.developers.client.api.ApiKeySecret
+import com.linecorp.link.developers.client.api.TestSocketUtils
+import com.linecorp.link.developers.client.request.OrderBy
+import com.linecorp.link.developers.client.response.NonFungibleTokenTypeHolderList
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import kotlin.test.assertTrue
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ApiClientNftHolderV2Test {
+    private val port = TestSocketUtils.findAvailableTcpPort()
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var retrofitApiClientFactory: RetrofitApiClientFactory
+
+    private val baseUrl = "http://localhost:$port"
+    private val apiKeySecret = ApiKeySecret(key = "test", secret = "test")
+
+    @BeforeEach
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start(port)
+        retrofitApiClientFactory = RetrofitApiClientFactory()
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun test_v2_nft_holder_query() {
+        val mockResponse = MockResponse()
+            .setResponseCode(200)
+            .setHeader("Content-Type", "application/json")
+            .setBody("""
+            {
+              "responseTime": 1683526595974,
+              "statusCode": 1000,
+              "statusMessage": "Success",
+              "responseData": {
+                    "list": [
+                      {
+                        "walletAddress": "tlink1z2y3xfvxq3xqrechtey05jea9krmkc3wd6dvx5",
+                        "userId": null,
+                        "numberOfIndex": "1022"
+                      },
+                      {
+                        "walletAddress": "tlink1tqhku70z8sla9py8zf76zn9pcnrcfppv2jzgwk",
+                        "userId": null,
+                        "numberOfIndex": "743"
+                      },
+                      {
+                        "walletAddress": "tlink1gmw0agxluucsg2ay87ruz5sl3g9e7dtclyuh7l",
+                        "userId": null,
+                        "numberOfIndex": "3"
+                      },
+                      {
+                        "walletAddress": "tlink16800lv0kjyv8pfnpe5jqmh7eshnsmdjvud5teu",
+                        "userId": null,
+                        "numberOfIndex": "239"
+                      },
+                      {
+                        "walletAddress": "tlink139972p0zjqt9q54sttv6q40hyqk9qvar8pffjj",
+                        "userId": null,
+                        "numberOfIndex": "18"
+                      }
+                    ],
+                    "prePageToken": "",
+                    "nextPageToken": "eJxtjssOgjAQRf9l1iwE1AA7REyICRrtQlekaaeRgAVqIaDh363PuHBWc09mTu4NKOcKL5dQ8qiSWlGmE7OVJTKdVzIVepWXGhUEt88pBKDLXBZ20bie6nh77Tu39YtBMEb9"
+                }
+              }
+            """.trimIndent())
+        
+        mockWebServer.enqueue(mockResponse)
+        
+        val apiClient = retrofitApiClientFactory.buildDefaultApiClient(
+            baseUrl = baseUrl,
+            enableLogging = true,
+            apiKeySecret = apiKeySecret
+        )
+
+        val response = runBlocking {
+            apiClient.nonFungibleTokenTypeHoldersV2(
+                contractId = "test1234",
+                tokenType = "10000001",
+                limit = 10,
+                pageToken = null,
+                orderBy = OrderBy.ASC
+            )
+        }
+        
+        assertTrue(response.responseData is NonFungibleTokenTypeHolderList)
+        assertEquals("tlink1z2y3xfvxq3xqrechtey05jea9krmkc3wd6dvx5", response.responseData!!.list.first().walletAddress)
+        assertEquals("eJxtjssOgjAQRf9l1iwE1AA7REyICRrtQlekaaeRgAVqIaDh363PuHBWc09mTu4NKOcKL5dQ8qiSWlGmE7OVJTKdVzIVepWXGhUEt88pBKDLXBZ20bie6nh77Tu39YtBMEb9", response.responseData!!.nextPageToken)
+    }
+}

--- a/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientNftHolderV2Test.kt
+++ b/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientNftHolderV2Test.kt
@@ -25,7 +25,6 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -70,7 +69,7 @@ class ApiClientNftHolderV2Test {
                         "walletAddress": "tlink1tqhku70z8sla9py8zf76zn9pcnrcfppv2jzgwk",
                         "userId": null,
                         "numberOfIndex": "743"
-                      },
+                        },client/response/responses.kt
                       {
                         "walletAddress": "tlink1gmw0agxluucsg2ay87ruz5sl3g9e7dtclyuh7l",
                         "userId": null,

--- a/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientNftHolderV2Test.kt
+++ b/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientNftHolderV2Test.kt
@@ -21,12 +21,12 @@ import com.linecorp.link.developers.client.api.ApiKeySecret
 import com.linecorp.link.developers.client.api.TestSocketUtils
 import com.linecorp.link.developers.client.request.OrderBy
 import com.linecorp.link.developers.client.response.NonFungibleTokenTypeHolderList
+import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
-import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ApiClientNftHolderV2Test {

--- a/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientNftHolderV2Test.kt
+++ b/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientNftHolderV2Test.kt
@@ -16,6 +16,7 @@
  */
 
 package com.linecorp.link.developers.client.api.retrofit
+
 import com.linecorp.link.developers.client.api.ApiKeySecret
 import com.linecorp.link.developers.client.api.TestSocketUtils
 import com.linecorp.link.developers.client.request.OrderBy
@@ -48,12 +49,14 @@ class ApiClientNftHolderV2Test {
         mockWebServer.shutdown()
     }
 
+    @Suppress("MaxLineLength", "LongMethod")
     @Test
-    fun test_v2_nft_holder_query() {
+    fun `testQueryNftHoldersV2`() {
         val mockResponse = MockResponse()
             .setResponseCode(200)
             .setHeader("Content-Type", "application/json")
-            .setBody("""
+            .setBody(
+                """
             {
               "responseTime": 1683526595974,
               "statusCode": 1000,
@@ -69,7 +72,7 @@ class ApiClientNftHolderV2Test {
                         "walletAddress": "tlink1tqhku70z8sla9py8zf76zn9pcnrcfppv2jzgwk",
                         "userId": null,
                         "numberOfIndex": "743"
-                        },client/response/responses.kt
+                      },
                       {
                         "walletAddress": "tlink1gmw0agxluucsg2ay87ruz5sl3g9e7dtclyuh7l",
                         "userId": null,
@@ -90,10 +93,11 @@ class ApiClientNftHolderV2Test {
                     "nextPageToken": "eJxtjssOgjAQRf9l1iwE1AA7REyICRrtQlekaaeRgAVqIaDh363PuHBWc09mTu4NKOcKL5dQ8qiSWlGmE7OVJTKdVzIVepWXGhUEt88pBKDLXBZ20bie6nh77Tu39YtBMEb9"
                 }
               }
-            """.trimIndent())
-        
+            """.trimIndent()
+            )
+
         mockWebServer.enqueue(mockResponse)
-        
+
         val apiClient = retrofitApiClientFactory.buildDefaultApiClient(
             baseUrl = baseUrl,
             enableLogging = true,
@@ -109,9 +113,15 @@ class ApiClientNftHolderV2Test {
                 orderBy = OrderBy.ASC
             )
         }
-        
+
         assertTrue(response.responseData is NonFungibleTokenTypeHolderList)
-        assertEquals("tlink1z2y3xfvxq3xqrechtey05jea9krmkc3wd6dvx5", response.responseData!!.list.first().walletAddress)
-        assertEquals("eJxtjssOgjAQRf9l1iwE1AA7REyICRrtQlekaaeRgAVqIaDh363PuHBWc09mTu4NKOcKL5dQ8qiSWlGmE7OVJTKdVzIVepWXGhUEt88pBKDLXBZ20bie6nh77Tu39YtBMEb9", response.responseData!!.nextPageToken)
+        assertEquals(
+            "tlink1z2y3xfvxq3xqrechtey05jea9krmkc3wd6dvx5",
+            response.responseData!!.list.first().walletAddress
+        )
+        assertEquals(
+            "eJxtjssOgjAQRf9l1iwE1AA7REyICRrtQlekaaeRgAVqIaDh363PuHBWc09mTu4NKOcKL5dQ8qiSWlGmE7OVJTKdVzIVepWXGhUEt88pBKDLXBZ20bie6nh77Tu39YtBMEb9",
+            response.responseData!!.nextPageToken
+        )
     }
 }


### PR DESCRIPTION
### What kind of change does this PR introduce?
* [ ] bug fix
* [x] feature
* [ ] docs
* [ ] update

### What is the current behavior? 
[Current API to query holders of NFTs of a specific type](https://docs-blockchain.line.biz/api-guide/category-item-tokens/retrieve#v1-item-tokens-contractId-non-fungibles-tokenType-holders-get) is a kind of slow, so there will be new API that faster than the [current API](https://docs-blockchain.line.biz/api-guide/category-item-tokens/retrieve#v1-item-tokens-contractId-non-fungibles-tokenType-holders-get)

### What is the new behavior?
New function for the new API
