### PR TITLE
feat: new api call to refresh nft token media resource for its type

### DIFF
--- a/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/ApiClient.kt
+++ b/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/ApiClient.kt
@@ -46,6 +46,7 @@ import com.linecorp.link.developers.client.request.ITEM_TOKEN_NFT_MEDIA_REFRESH_
 import com.linecorp.link.developers.client.request.ITEM_TOKEN_NFT_MEDIA_RESOURCE_REFRESH_PATH
 import com.linecorp.link.developers.client.request.ITEM_TOKEN_NFT_THUMBNAIL_REFRESH_PATH
 import com.linecorp.link.developers.client.request.ITEM_TOKEN_NFT_THUMBNAIL_REFRESH_STATUS_PATH
+import com.linecorp.link.developers.client.request.ITEM_TOKEN_NFT_TYPE_MEDIA_RESOURCE_REFRESH_PATH
 import com.linecorp.link.developers.client.request.ITEM_TOKEN_PATH
 import com.linecorp.link.developers.client.request.IssueServiceTokenRequest
 import com.linecorp.link.developers.client.request.MEMO_BY_TX_HASH_PATH
@@ -105,6 +106,7 @@ import com.linecorp.link.developers.client.request.USER_SERVICE_TOKEN_IS_PROXY_P
 import com.linecorp.link.developers.client.request.USER_SERVICE_TOKEN_TRANSFER_PATH
 import com.linecorp.link.developers.client.request.UpdateFungibleTokenResourceRequest
 import com.linecorp.link.developers.client.request.UpdateNonFungibleTokenResourceRequest
+import com.linecorp.link.developers.client.request.UpdateNonFungibleTypeTokenResourceRequest
 import com.linecorp.link.developers.client.request.UpdateServiceTokenRequest
 import com.linecorp.link.developers.client.request.UserAssetProxyRequest
 import com.linecorp.link.developers.client.request.UserServiceTokenTransferRequest
@@ -973,6 +975,12 @@ interface ApiClient {
     suspend fun updateNonFungibleItemTokensMediaResource(
         @Path("contractId") contractId: String,
         @Body request: UpdateNonFungibleTokenResourceRequest,
+    ): GenericResponse<UpdateTokenMediaRefreshResponse>
+
+    @PUT(ITEM_TOKEN_NFT_TYPE_MEDIA_RESOURCE_REFRESH_PATH)
+    suspend fun updateNonFungibleTypeItemTokensMediaResource(
+        @Path("contractId") contractId: String,
+        @Body request: UpdateNonFungibleTypeTokenResourceRequest,
     ): GenericResponse<UpdateTokenMediaRefreshResponse>
 
     @PUT(ITEM_TOKEN_FT_THUMBNAIL_REFRESH_PATH)

--- a/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/ApiClient.kt
+++ b/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/api/ApiClient.kt
@@ -47,6 +47,7 @@ import com.linecorp.link.developers.client.request.ITEM_TOKEN_NFT_MEDIA_RESOURCE
 import com.linecorp.link.developers.client.request.ITEM_TOKEN_NFT_THUMBNAIL_REFRESH_PATH
 import com.linecorp.link.developers.client.request.ITEM_TOKEN_NFT_THUMBNAIL_REFRESH_STATUS_PATH
 import com.linecorp.link.developers.client.request.ITEM_TOKEN_NFT_TYPE_MEDIA_RESOURCE_REFRESH_PATH
+import com.linecorp.link.developers.client.request.ITEM_TOKEN_NFT_TYPE_THUMBNAIL_REFRESH_PATH
 import com.linecorp.link.developers.client.request.ITEM_TOKEN_PATH
 import com.linecorp.link.developers.client.request.IssueServiceTokenRequest
 import com.linecorp.link.developers.client.request.MEMO_BY_TX_HASH_PATH
@@ -978,7 +979,7 @@ interface ApiClient {
     ): GenericResponse<UpdateTokenMediaRefreshResponse>
 
     @PUT(ITEM_TOKEN_NFT_TYPE_MEDIA_RESOURCE_REFRESH_PATH)
-    suspend fun updateNonFungibleTypeItemTokensMediaResource(
+    suspend fun updateNonFungibleItemTokenTypesMediaResource(
         @Path("contractId") contractId: String,
         @Body request: UpdateNonFungibleTypeTokenResourceRequest,
     ): GenericResponse<UpdateTokenMediaRefreshResponse>
@@ -993,6 +994,12 @@ interface ApiClient {
     suspend fun updateNonFungibleItemTokensThumbnail(
         @Path("contractId") contractId: String,
         @Body request: UpdateNonFungibleTokenResourceRequest,
+    ): GenericResponse<UpdateTokenMediaRefreshResponse>
+
+    @PUT(ITEM_TOKEN_NFT_TYPE_THUMBNAIL_REFRESH_PATH)
+    suspend fun updateNonFungibleItemTokenTypesThumbnail(
+        @Path("contractId") contractId: String,
+        @Body request: UpdateNonFungibleTypeTokenResourceRequest,
     ): GenericResponse<UpdateTokenMediaRefreshResponse>
 
     @GET(TX_MESSAGES_PATH)

--- a/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/request/request-path-list.kt
+++ b/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/request/request-path-list.kt
@@ -163,7 +163,10 @@ const val USER_NON_FUNGIBLE_TOKEN_BATCH_TRANSFER_PATH =
 const val ITEM_TOKEN_FT_MEDIA_RESOURCE_REFRESH_PATH = "$V1/item-tokens/{contractId}/fungibles/media-resources"
 const val ITEM_TOKEN_FT_THUMBNAIL_REFRESH_PATH = "$V1/item-tokens/{contractId}/fungibles/thumbnails"
 const val ITEM_TOKEN_NFT_MEDIA_RESOURCE_REFRESH_PATH = "$V1/item-tokens/{contractId}/non-fungibles/media-resources"
+
+@Suppress("MaxLineLength")
 const val ITEM_TOKEN_NFT_TYPE_MEDIA_RESOURCE_REFRESH_PATH = "$V1/item-tokens/{contractId}/non-fungibles/types/media-resources"
 const val ITEM_TOKEN_NFT_THUMBNAIL_REFRESH_PATH = "$V1/item-tokens/{contractId}/non-fungibles/thumbnails"
+const val ITEM_TOKEN_NFT_TYPE_THUMBNAIL_REFRESH_PATH = "$V1/item-tokens/{contractId}/non-fungibles/types/thumbnails"
 
 const val TX_MESSAGES_PATH = "$V2_TRANSACTION_PATH/messages"

--- a/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/request/request-path-list.kt
+++ b/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/request/request-path-list.kt
@@ -163,6 +163,7 @@ const val USER_NON_FUNGIBLE_TOKEN_BATCH_TRANSFER_PATH =
 const val ITEM_TOKEN_FT_MEDIA_RESOURCE_REFRESH_PATH = "$V1/item-tokens/{contractId}/fungibles/media-resources"
 const val ITEM_TOKEN_FT_THUMBNAIL_REFRESH_PATH = "$V1/item-tokens/{contractId}/fungibles/thumbnails"
 const val ITEM_TOKEN_NFT_MEDIA_RESOURCE_REFRESH_PATH = "$V1/item-tokens/{contractId}/non-fungibles/media-resources"
+const val ITEM_TOKEN_NFT_TYPE_MEDIA_RESOURCE_REFRESH_PATH = "$V1/item-tokens/{contractId}/non-fungibles/types/media-resources"
 const val ITEM_TOKEN_NFT_THUMBNAIL_REFRESH_PATH = "$V1/item-tokens/{contractId}/non-fungibles/thumbnails"
 
 const val TX_MESSAGES_PATH = "$V2_TRANSACTION_PATH/messages"

--- a/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/request/requests.kt
+++ b/libs/developers-api-client/src/main/kotlin/com/linecorp/link/developers/client/request/requests.kt
@@ -718,4 +718,13 @@ data class UpdateNonFungibleTokenResourceRequest(val updateList: List<NonFungibl
     }
 }
 
+data class UpdateNonFungibleTypeTokenResourceRequest(
+    val updateList: List<TokenType>
+) : AbstractUpdateTokenResourceRequest<TokenType>(updateList) {
+    override fun hasInvalidTokenId(): Boolean {
+        return updateList
+            .any { TokenUtil.filterInvalidItemTokenType(it.tokenType) }
+    }
+}
+
 data class NonFungibleTokenIdentifier(val tokenType: String, val tokenIndex: String)

--- a/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/ApiListTest.kt
+++ b/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/ApiListTest.kt
@@ -17,6 +17,7 @@
 
 package com.linecorp.link.developers.client.api
 
+import com.linecorp.link.developers.client.request.V1
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import retrofit2.http.DELETE
@@ -153,7 +154,9 @@ class ApiListTest {
             "PUT /v1/item-tokens/{contractId}/fungibles/media-resources",
             "PUT /v1/item-tokens/{contractId}/fungibles/thumbnails",
             "PUT /v1/item-tokens/{contractId}/non-fungibles/media-resources",
+            "PUT /v1/item-tokens/{contractId}/non-fungibles/types/media-resources",
             "PUT /v1/item-tokens/{contractId}/non-fungibles/thumbnails",
+            "PUT /v1/item-tokens/{contractId}/non-fungibles/types/thumbnails",
             "PUT /v1/item-tokens/{contractId}/non-fungibles/{tokenType}",
             "POST /v1/item-tokens/{contractId}/fungibles/{tokenType}/burn",
             "POST /v1/item-tokens/{contractId}/non-fungibles/{tokenType}/{tokenIndex}/burn",

--- a/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientNftTokenMediaResourceUpdateByType.kt
+++ b/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientNftTokenMediaResourceUpdateByType.kt
@@ -1,0 +1,99 @@
+/*
+ *   Copyright 2023 LINE Corporation
+ *
+ *   LINE Corporation licenses this file to you under the Apache License,
+ *   version 2.0 (the "License"); you may not use this file except in compliance
+ *   with the License. You may obtain a copy of the License at:
+ *
+ *     https:www.apache.orglicensesLICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *   License for the specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+
+package com.linecorp.link.developers.client.api.retrofit
+
+import com.linecorp.link.developers.client.api.ApiKeySecret
+import com.linecorp.link.developers.client.api.TestSocketUtils
+import com.linecorp.link.developers.client.request.OrderBy
+import com.linecorp.link.developers.client.request.TokenType
+import com.linecorp.link.developers.client.request.UpdateNonFungibleTypeTokenResourceRequest
+import com.linecorp.link.developers.client.response.NonFungibleTokenTypeHolderList
+import com.linecorp.link.developers.client.response.UpdateTokenMediaRefreshResponse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import kotlin.test.assertNotNull
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ApiClientNftTokenMediaResourceUpdateByType {
+    private val port = TestSocketUtils.findAvailableTcpPort()
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var retrofitApiClientFactory: RetrofitApiClientFactory
+
+    private val baseUrl = "http://localhost:$port"
+    private val apiKeySecret = ApiKeySecret(key = "test", secret = "test")
+
+    @BeforeEach
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start(port)
+        retrofitApiClientFactory = RetrofitApiClientFactory()
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        mockWebServer.shutdown()
+    }
+
+    @Suppress("MaxLineLength", "LongMethod")
+    @Test
+    fun `testUpdateNonFungibleTypeItemTokensMediaResource()`() {
+        val mockResponse = MockResponse()
+            .setResponseCode(202)
+            .setHeader("Content-Type", "application/json")
+            .setBody(
+                """
+                {
+                    "responseTime": 1585467713049,
+                    "statusCode": 1002,
+                    "statusMessage": "Accepted",
+                    "responseData": {
+                        "requestId": "test1234"
+                    }
+                } 
+            """.trimIndent()
+            )
+
+        mockWebServer.enqueue(mockResponse)
+
+        val apiClient = retrofitApiClientFactory.buildDefaultApiClient(
+            baseUrl = baseUrl,
+            enableLogging = true,
+            apiKeySecret = apiKeySecret
+        )
+
+        val response = runBlocking {
+            apiClient.updateNonFungibleTypeItemTokensMediaResource(
+                contractId = "test1234",
+                request = UpdateNonFungibleTypeTokenResourceRequest(
+                    updateList = listOf(
+                        TokenType(
+                            tokenType = "10000001"
+                        )
+                    )
+                )
+            )
+        }
+
+        assertTrue(response.responseData is UpdateTokenMediaRefreshResponse)
+        assertNotNull(response.responseData!!.requestId)
+    }
+}

--- a/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientNftTypeTokenMediaResourceUpdate.kt
+++ b/libs/developers-api-client/src/test/kotlin/com/linecorp/link/developers/client/api/retrofit/ApiClientNftTypeTokenMediaResourceUpdate.kt
@@ -19,21 +19,18 @@ package com.linecorp.link.developers.client.api.retrofit
 
 import com.linecorp.link.developers.client.api.ApiKeySecret
 import com.linecorp.link.developers.client.api.TestSocketUtils
-import com.linecorp.link.developers.client.request.OrderBy
 import com.linecorp.link.developers.client.request.TokenType
 import com.linecorp.link.developers.client.request.UpdateNonFungibleTypeTokenResourceRequest
-import com.linecorp.link.developers.client.response.NonFungibleTokenTypeHolderList
 import com.linecorp.link.developers.client.response.UpdateTokenMediaRefreshResponse
-import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.*
-import org.junit.jupiter.api.Assertions.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class ApiClientNftTokenMediaResourceUpdateByType {
+class ApiClientNftTypeTokenMediaResourceUpdate {
     private val port = TestSocketUtils.findAvailableTcpPort()
     private lateinit var mockWebServer: MockWebServer
     private lateinit var retrofitApiClientFactory: RetrofitApiClientFactory
@@ -41,7 +38,7 @@ class ApiClientNftTokenMediaResourceUpdateByType {
     private val baseUrl = "http://localhost:$port"
     private val apiKeySecret = ApiKeySecret(key = "test", secret = "test")
 
-    @BeforeEach
+    @BeforeAll
     fun setUp() {
         mockWebServer = MockWebServer()
         mockWebServer.start(port)
@@ -81,7 +78,51 @@ class ApiClientNftTokenMediaResourceUpdateByType {
         )
 
         val response = runBlocking {
-            apiClient.updateNonFungibleTypeItemTokensMediaResource(
+            apiClient.updateNonFungibleItemTokenTypesMediaResource(
+                contractId = "test1234",
+                request = UpdateNonFungibleTypeTokenResourceRequest(
+                    updateList = listOf(
+                        TokenType(
+                            tokenType = "10000001"
+                        )
+                    )
+                )
+            )
+        }
+
+        assertTrue(response.responseData is UpdateTokenMediaRefreshResponse)
+        assertNotNull(response.responseData!!.requestId)
+    }
+
+    @Suppress("MaxLineLength", "LongMethod")
+    @Test
+    fun `testUpdateNonFungibleTypeItemTokensThumbnails()`() {
+        val mockResponse = MockResponse()
+            .setResponseCode(202)
+            .setHeader("Content-Type", "application/json")
+            .setBody(
+                """
+                {
+                    "responseTime": 1585467713049,
+                    "statusCode": 1002,
+                    "statusMessage": "Accepted",
+                    "responseData": {
+                        "requestId": "test1234"
+                    }
+                } 
+            """.trimIndent()
+            )
+
+        mockWebServer.enqueue(mockResponse)
+
+        val apiClient = retrofitApiClientFactory.buildDefaultApiClient(
+            baseUrl = baseUrl,
+            enableLogging = true,
+            apiKeySecret = apiKeySecret
+        )
+
+        val response = runBlocking {
+            apiClient.updateNonFungibleItemTokenTypesThumbnail(
                 contractId = "test1234",
                 request = UpdateNonFungibleTypeTokenResourceRequest(
                     updateList = listOf(


### PR DESCRIPTION
### What kind of change does this PR introduce?
* [ ] bug fix
* [x] feature
* [ ] docs
* [ ] update

### What is the current behavior?
There is no API to refresh token media resource for nft's type

### What is the new behavior?
New function to call the API